### PR TITLE
Prepare and init phase

### DIFF
--- a/src/components/WorkflowsExplorer/Timeline/Footer/MinimapFooter.tsx
+++ b/src/components/WorkflowsExplorer/Timeline/Footer/MinimapFooter.tsx
@@ -93,14 +93,14 @@ const MinimapFooter: React.FC<MinimapFooterProps> = ({
 
         if (timeline.sortBy !== 'duration') {
           const { start, end } = startAndEndpointsOfRows(grp);
-          return { status, start, end: status === 'running' ? timeline.endTime : end };
+          return { status, start, end: status === 'RUNNING' ? timeline.endTime : end };
         } else {
           const timings = startAndEndpointsOfRows(grp);
           const longest = getLongestRowDuration(grp);
 
           return {
-            start: status === 'running' ? timeline.startTime : timings.start,
-            end: status === 'running' ? timeline.endTime : timings.start + longest,
+            start: status === 'RUNNING' ? timeline.startTime : timings.start,
+            end: status === 'RUNNING' ? timeline.endTime : timings.start + longest,
             status,
           };
         }

--- a/src/components/WorkflowsExplorer/Timeline/TimelineRow/LineElement.tsx
+++ b/src/components/WorkflowsExplorer/Timeline/TimelineRow/LineElement.tsx
@@ -86,7 +86,7 @@ const LineElement: React.FC<LineElementProps> = ({
         }}
         data-testid="boxgraphic"
         dragging={dragging}
-        title={formatDuration(duration) + `${status === 'unknown' ? ` (${t('task.unable-to-find-status')})` : ''}`}
+        title={formatDuration(duration) + `${status === 'UNKNOWN' ? ` (${t('task.unable-to-find-status')})` : ''}`}
         onClick={(e) => {
           if (row.type === 'task') {
             e.stopPropagation();
@@ -95,7 +95,7 @@ const LineElement: React.FC<LineElementProps> = ({
           }
         }}
       >
-        {(isLastAttempt || status === 'running') && (
+        {(isLastAttempt || status === 'RUNNING') && (
           <RowMetricLabel duration={duration} labelPosition={labelPosition} data-testid="boxgraphic-label" />
         )}
         <BoxGraphicLine grayed={grayed} state={status} isLastAttempt={isLastAttempt} />

--- a/src/components/WorkflowsExplorer/Timeline/TimelineRow/utils.ts
+++ b/src/components/WorkflowsExplorer/Timeline/TimelineRow/utils.ts
@@ -37,7 +37,7 @@ export function getRowStatus(
     if (row.data.status) {
       return row.data.status;
     } else {
-      return row.data.finished_at ? 'completed' : 'running';
+      return row.data.finished_at ? 'SUCCEEDED' : 'RUNNING';
     }
   }
 }
@@ -47,17 +47,20 @@ export function lineColor(theme: DefaultTheme, grayed: boolean, state: string, i
     return '#c7c7c7';
   } else {
     switch (state) {
-      case 'completed':
-      case 'ok':
+      case 'SUCCEEDED':
         return !isFirst ? lighten(0.3, theme.color.bg.red) : theme.color.bg.green;
-      case 'running':
+      case 'RUNNING':
         return theme.color.bg.greenLight;
-      case 'pending':
+      case 'PENDING':
         return theme.color.bg.yellow;
-      case 'failed':
+      case 'FAILED':
         return !isFirst ? lighten(0.3, theme.color.bg.red) : theme.color.bg.red;
-      case 'unknown':
+      case 'SKIPPED':
         return !isFirst ? lighten(0.3, theme.color.bg.dark) : theme.color.bg.dark;
+      case 'INITIALIZED':
+        return !isFirst ? lighten(0.3, theme.color.bg.blue) : theme.color.bg.blue;
+      case 'PREPARED':
+        return !isFirst ? lighten(0.3, theme.color.bg.violet) : theme.color.bg.violet;
       default:
         return lighten(0.5, theme.color.bg.dark);
     }

--- a/src/components/WorkflowsExplorer/Timeline/taskdataUtils.ts
+++ b/src/components/WorkflowsExplorer/Timeline/taskdataUtils.ts
@@ -118,14 +118,14 @@ export function getStepStatus(stepTaskData: Record<string, Row[]>): TaskStatus {
   for (const data of Object.entries(stepTaskData)) {
     const statuses = data[1].map((item) => item.status);
     const statusOfLastItem = statuses[statuses.length - 1];
-    if (statusOfLastItem === 'running') {
-      return 'running';
+    if (statusOfLastItem === 'RUNNING') {
+      return 'RUNNING';
     }
-    if (statusOfLastItem === 'failed') {
-      return 'failed';
+    if (statusOfLastItem === 'FAILED') {
+      return 'FAILED';
     }
   }
-  return 'completed';
+  return 'SUCCEEDED';
 }
 
 //

--- a/src/components/WorkflowsExplorer/ToolBar/FilterMenu.tsx
+++ b/src/components/WorkflowsExplorer/ToolBar/FilterMenu.tsx
@@ -1,7 +1,7 @@
 import { Button, Checkbox, Menu, Sheet } from "@mui/joy";
 import React, { useEffect, useState } from "react";
 import { Row } from "../../../types";
-import { getButtonColor, getIcon, getSDLBStatus } from "../../../util/WorkflowsExplorer/StatusInfo";
+import { getButtonColor, getIcon } from "../../../util/WorkflowsExplorer/StatusInfo";
 /**
  * The FilterMenu component is a subcomponent of the ToolBar component that implements the filter functionality.
  * It updates the list of filters that are passed to it based on the user's input.
@@ -68,7 +68,7 @@ const FilterMenu = (props: {updateList: (list: boolean[]) => void, style?: 'vert
                         }}
                     >
                             <Checkbox 
-                                color={getButtonColor(getSDLBStatus(filter.name.toLowerCase()))}
+                                color={getButtonColor(filter.name.toUpperCase())}
                                 size="sm"
                                 variant="outlined"
                                 checked={list[index]}
@@ -80,7 +80,7 @@ const FilterMenu = (props: {updateList: (list: boolean[]) => void, style?: 'vert
                                 }}
                             /> 
                             {filter.name}
-                            {getIcon(getSDLBStatus(filter.name.toLowerCase()))}
+                            {getIcon(filter.name.toUpperCase())}
                     </Sheet>
                 </>
             ))}

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -47,6 +47,7 @@ declare module 'styled-components' {
         red: string;
         green: string;
         greenLight: string;
+        violet: string;
       };
       text: {
         white: string;

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -11,7 +11,7 @@ const spacer = {
 
 const brandColor = {
   gray: '#333',
-  blue: '#146EE6',
+  blue: '#096bde',
   teal: '#00BBCE',
 };
 
@@ -31,13 +31,14 @@ const bgColor = {
   black: '#444',
   light: 'rgba(0,0,0,0.03)', // '#f6f6f6',
   blue: brandColor.blue,
-  blueLight: '#e4f0ff',
+  blueLight: '#b5d7ff',
   silver: '#E8EAED',
   teal: brandColor.teal,
   yellow: '#E5A90C',
   red: '#EB3428',
   green: '#20AF2E',
   greenLight: '#BCE307',
+  violet: '#a023e8',
 };
 
 const borderColor = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,14 +59,14 @@ export class Row implements MetaDataBaseObject {
     foreach_label?: string;
     metadata: Metadata;
     message: string;
-    
+   
     constructor({ properties }: { properties: TaskProperty; }) {
       this.flow_id = properties.runInfo.workflowName;
       this.step_name = properties.actionName;
       this.run_number = properties.runInfo.runId;
       this.attempt_id = properties.runInfo.attemptId;
       this.ts_epoch = new Date(properties.action.startTstmp).getTime();
-      this.status = properties.action.state === 'SUCCEEDED' ? 'completed' : (properties.action.state === 'FAILED' ? 'failed' : 'unknown');
+      this.status = properties.action.state as TaskStatus;
       this.started_at = this.ts_epoch;
       this.duration = durationMicro(properties.action.duration === 'PT0S' ? 'PT0.001S' : properties.action.duration);
       this.finished_at = this.started_at + (this.duration === 0 ? 1 : this.duration);
@@ -89,7 +89,7 @@ export class Row implements MetaDataBaseObject {
      * current time. Note that we are not camparing current time to ts_epoch field, which is just time for task object, not actual task time itself.
      */
     getTaskDuration(): number | null {
-      return this.status === 'running' && this.started_at
+      return this.status === 'RUNNING' && this.started_at
         ? Date.now() - this.started_at
         : this.duration
         ? this.duration
@@ -98,7 +98,7 @@ export class Row implements MetaDataBaseObject {
   }
   
   
-  export type TaskStatus = 'running' | 'completed' | 'failed' | 'unknown' | 'pending' | 'refining';
+  export type TaskStatus = 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'SKIPPED' | 'PREPARED' | 'INITIALIZED';
   
   export interface TaskProperty {
     runInfo: RunInfo,

--- a/src/util/WorkflowsExplorer/StatusInfo.tsx
+++ b/src/util/WorkflowsExplorer/StatusInfo.tsx
@@ -21,7 +21,7 @@ export const getButtonColor = (name: string) => {
 }
 
 export const getIcon = (status: string) => {
-    const tmp = getButtonColor(getSDLBStatus(status));
+    const tmp = getButtonColor(status);
     const color = tmp === 'neutral' ? 'disabled' : (tmp === 'danger' ? 'error' : tmp);
 
     switch (status) {
@@ -59,13 +59,4 @@ export const checkFiltersAvailability = (rows: any, filters: any[]) => {
         }
     });
     return availableFilters;
-}
-
-export const getSDLBStatus = (status: string) => {
-    if (status === 'SUCCEEDED') {
-        return 'SUCCEEDED';
-    } else if (status === 'SKIPPED') {
-        return 'SKIPPED';
-    } 
-    return status;
 }

--- a/src/util/WorkflowsExplorer/StatusInfo.tsx
+++ b/src/util/WorkflowsExplorer/StatusInfo.tsx
@@ -47,9 +47,7 @@ export const defaultFilters = (columnName?: string) => {
         {name: 'Failed', fun: (rows: any) => {return rows.filter(row => row[column] === 'FAILED')}},
         {name: 'Prepared', fun: (rows: any) => {return rows.filter(row => row[column] === 'PREPARED')}},
         {name: 'Initialized', fun: (rows: any) => {return rows.filter(row => row[column] === 'INITIALIZED')}},
-        {name: 'Completed', fun: (rows: any) => {return rows.filter(row => row[column] === 'completed')}},
-        {name: 'Unknown', fun: (rows: any) => {return rows.filter(row => row[column] === 'unknown')}},
-        {name: 'Failed', fun: (rows: any) => {return rows.filter(row => row[column] === 'failed')}},
+        {name: 'Skipped', fun: (rows: any) => {return rows.filter(row => row[column] === 'SKIPPED')}},
     ]
 };
 
@@ -64,9 +62,9 @@ export const checkFiltersAvailability = (rows: any, filters: any[]) => {
 }
 
 export const getSDLBStatus = (status: string) => {
-    if (status === 'completed') {
+    if (status === 'SUCCEEDED') {
         return 'SUCCEEDED';
-    } else if (status === 'unknown') {
+    } else if (status === 'SKIPPED') {
         return 'SKIPPED';
     } 
     return status;

--- a/src/util/WorkflowsExplorer/row.ts
+++ b/src/util/WorkflowsExplorer/row.ts
@@ -60,19 +60,21 @@ export const getLongestRowDuration = (rows: Row[]): number => {
  */
 export const getTaskLineStatus = (rows: Row[]): TaskStatus => {
   const statuses = rows.map((row) => {
-    return row.status || 'unknown';
+    return row.status || 'UNKNOWN';
   });
-  if (statuses.indexOf('running') > -1) return 'running';
-  if (statuses.indexOf('failed') > -1) return 'failed';
-  if (statuses.indexOf('unknown') > -1) return 'unknown';
-  return 'completed';
+  if (statuses.indexOf('RUNNING') > -1) return 'RUNNING';
+  if (statuses.indexOf('FAILED') > -1) return 'FAILED';
+  if (statuses.indexOf('SKIPPED') > -1) return 'SKIPPED';
+  if (statuses.indexOf('PREPARED') > -1) return 'PREPARED';
+  if (statuses.indexOf('INITIALIZED') > -1) return 'INITIALIZED';
+  return 'SUCCEEDED';
 };
 
 /**
  * Get current step name	
  */
 export const getCurrentStepName = (rows: Row[]): string =>
-  rows.find((row) => row.status === 'running')?.step_name || '';
+  rows.find((row) => row.status === 'RUNNING')?.step_name || '';
 
 
 export const sortRows = (rows: any, sortType: SortType) => {

--- a/src/util/WorkflowsExplorer/style.ts
+++ b/src/util/WorkflowsExplorer/style.ts
@@ -32,14 +32,18 @@ export function toRelativeSize(normalsize: number): number {
  */
 export function colorByStatus(theme: DefaultTheme, status: string): string {
   switch (status) {
-    case 'completed':
+    case 'SUCCEEEDED':
       return theme.color.bg.green;
-    case 'failed':
+    case 'FAILED':
       return theme.color.bg.red;
-    case 'running':
+    case 'RUNNING':
       return theme.color.bg.greenLight;
-    case 'pending':
+    case 'PENDING':
       return theme.color.bg.yellow;
+    case 'INITIALIZED':
+      return theme.color.bg.blue;
+    case 'PREPARED':
+      return theme.color.bg.violet;
     default:
       return theme.color.bg.dark;
   }

--- a/src/util/WorkflowsExplorer/task.ts
+++ b/src/util/WorkflowsExplorer/task.ts
@@ -12,7 +12,7 @@ export function getTaskId(task: Row): string {
  * current time. Note that we are not camparing current time to ts_epoch field, which is just time for task object, not actual task time itself.
  */
 export function getTaskDuration(task: Row): number | null {
-  return task.status === 'running' && task.started_at
+  return task.status === 'RUNNING' && task.started_at
     ? Date.now() - task.started_at
     : task.duration
     ? task.duration


### PR DESCRIPTION
# What's new 
- The timeline now displays actions with "INITIALIZED" and "PREPARED" statuses with the correct color
- SDLB actions' status are directly compatible with the Metaflow timeline component "actions/steps" elements (no need to convert the TaskStatus type anymore)