### PR TITLE
Lineage for individual runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "react-tooltip": "^4.2.17",
     "react-virtualized": "^9.21.2",
+    "reactflow": "^11.7.3",
     "recharts": "^2.5.0",
     "reconnecting-websocket": "^4.4.0",
     "remark-gfm": "^3.0.1",

--- a/public/state/random/manual_prepareinit.1.1.json
+++ b/public/state/random/manual_prepareinit.1.1.json
@@ -1,0 +1,105 @@
+{
+  "appConfig" : {
+    "feedSel" : ".*",
+    "applicationName" : "manual_671_prepareinit",
+    "configuration" : [ "C:\\coding\\projects\\smart-data-lake/sdl-core/src/main/resources/application.conf" ],
+    "master" : "local[*]",
+    "deployMode" : "client",
+    "parallelism" : 1,
+    "statePath" : "C:\\coding\\projects\\smart-data-lake/target/state",
+    "streaming" : false
+  },
+  "runId" : 1,
+  "attemptId" : 1,
+  "runStartTime" : "2023-06-08T10:22:26.344865100",
+  "attemptStartTime" : "2023-06-08T10:22:26.346865500",
+  "actionsState" : {
+    "select-airport-cols" : {
+      "executionId" : {
+        "type" : "SDLExecutionId",
+        "runId" : 2,
+        "attemptId" : 1
+      },
+      "state" : "SUCCEEDED",
+      "startTstmpPrepare" : "2023-06-08T10:22:31.551462100",
+      "endTstmpPrepare" : "2023-06-08T10:22:38.869341800",
+      "startTstmpInit" : "2023-06-08T10:22:38.921576600",
+      "endTstmpInit" : "2023-06-08T10:22:49.480911300",
+      "startTstmp" : "2023-06-08T10:22:50.778694400",
+      "endTstmp" : "2023-06-08T10:22:54.518194700",
+      "duration" : "PT3.7395003S",
+      "results" : [ {
+        "subFeed" : {
+          "type" : "SparkSubFeed",
+          "dataObjectId" : "int-airports",
+          "partitionValues" : [ ],
+          "isDAGStart" : false,
+          "isSkipped" : false,
+          "isDummy" : false
+        },
+        "mainMetrics" : {
+          "stage" : "save",
+          "num_tasks" : 3,
+          "records_written" : 67481,
+          "stage_duration" : "PT2.138S",
+          "bytes_written" : 3878112
+        }
+      } ],
+      "dataObjectsState" : [ ],
+      "inputIds" : [ {
+        "id" : "stg-airports"
+      } ],
+      "outputIds" : [ {
+        "id" : "int-airports"
+      } ]
+    },
+    "join-departures-airports" : {
+      "executionId" : {
+        "type" : "SDLExecutionId",
+        "runId" : 2,
+        "attemptId" : 1
+      },
+      "state" : "SUCCEEDED",
+      "startTstmpPrepare" : "2023-06-08T10:22:38.882854300",
+      "endTstmpPrepare" : "2023-06-08T10:22:38.885854800",
+      "startTstmpInit" : "2023-06-08T10:22:49.492910900",
+      "endTstmpInit" : "2023-06-08T10:22:50.763699600",
+      "startTstmp" : "2023-06-08T10:22:54.662984100",
+      "endTstmp" : "2023-06-08T10:22:58.546515100",
+      "duration" : "PT3.883531S",
+      "results" : [ {
+        "subFeed" : {
+          "type" : "SparkSubFeed",
+          "dataObjectId" : "btl-departures-arrivals-airports",
+          "partitionValues" : [ ],
+          "isDAGStart" : false,
+          "isSkipped" : false,
+          "isDummy" : false
+        },
+        "mainMetrics" : {
+          "stage" : "save",
+          "num_tasks" : 3,
+          "records_written" : 26,
+          "stage_duration" : "PT0.401S",
+          "bytes_written" : 3035
+        }
+      } ],
+      "dataObjectsState" : [ ],
+      "inputIds" : [ {
+        "id" : "stg-departures"
+      }, {
+        "id" : "int-airports"
+      } ],
+      "outputIds" : [ {
+        "id" : "btl-departures-arrivals-airports"
+      } ]
+    }
+  },
+  "isFinal" : true,
+  "runStateFormatVersion" : 2,
+  "buildVersionInfo" : {
+    "version" : "2.5.1-SNAPSHOT",
+    "user" : "pgr",
+    "date" : "2023-06-08T10:09:40.656992200"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,8 +40,8 @@ export default function App() {
         <Route path='/' element={<Home/>}/>
         <Route path='/workflows/' element={<Workflows/>}/>
         <Route path='/workflows/:workflow' element={<WorkflowHistory/>}/>
-        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab' element={<Run lineageData={configData}/>}/>
-        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run lineageData={configData} panelOpen={true}/>}/>
+        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab' element={<Run configData={configData}/>}/>
+        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run configData={configData} panelOpen={true}/>}/>
         <Route path='*' element={<NotFound/>}/>
         <Route path='/config' element={<ConfigExplorer data={configData}/>}>
           <Route

--- a/src/components/ConfigExplorer/ConfigExplorer.tsx
+++ b/src/components/ConfigExplorer/ConfigExplorer.tsx
@@ -18,9 +18,7 @@ function ConfigExplorer(props: {data: any}) {
     	<Sheet
 			sx={{
 				display: 'flex',
-				justifyContent: 'flex-start',
-				gap: '1rem',
-				overflow: 'hidden'
+				height: '86vh',
 			}}
 			>
     	  	<ElementList data={data} />

--- a/src/components/ConfigExplorer/ConfigurationTab.tsx
+++ b/src/components/ConfigExplorer/ConfigurationTab.tsx
@@ -156,9 +156,7 @@ export default function ConfigurationTab(props: ElementProps) {
   let topAttributesCmp = createPropertiesComponent({properties: topAttributesPrep, width: "100%", rowHeight: "45px"})
 
   return (
-    <Box>
-      <Grid container spacing={2}>
-        <Grid item xs={12} xl={6}>
+    <Box sx={{display: 'flex', flexDirection: 'column', gap: '1rem'}}>
           <Box>
           {typeChip()}
           {feedChip()}
@@ -166,11 +164,9 @@ export default function ConfigurationTab(props: ElementProps) {
           {subjectAreaChip()}
           {tags.map(tag => createSearchChip("tags", tag, <SellIcon />, "secondary"))}
           </Box>
-        </Grid>
         {topAttributesCmp && <Grid item xs={12} xl={6}>{topAttributesCmp}</Grid>}
         {inputs.length > 0 && <Grid item xs={12} xl={6}>{formatInputsOutputs(inputs,outputs)}</Grid>}
-        <Grid item xs={12}>{mainContent()}</Grid>
-      </Grid>
+        {mainContent()}
     </Box>
   )
 }

--- a/src/components/ConfigExplorer/DataDisplayView.tsx
+++ b/src/components/ConfigExplorer/DataDisplayView.tsx
@@ -39,8 +39,8 @@ export default function DataDisplayView(props: displayProps) {
   };
 
   return (
-	<Sheet sx={{display: 'flex', height: '100%', flex: 1, p: '1rem'}}>
-		<Sheet sx={{display: 'flex', flexDirection: 'column', flex: 2, overflowY: 'scroll', scrollbarWidth: 'none'}}>
+	<Sheet sx={{display: 'flex', height: '100%', flex: 1,}}>
+		<Sheet sx={{display: 'flex', flexDirection: 'column', flex: 2, overflowY: 'scroll', scrollbarWidth: 'none',  p: '1rem'}}>
 
 			<TabContext value={selectedTyp}>
 				<Sheet sx={{ display: 'flex', justifyContent: 'space-between', position: 'sticky'}}>
@@ -62,7 +62,7 @@ export default function DataDisplayView(props: displayProps) {
 				</TabPanel>
 			</TabContext> 
 		</Sheet>
-		<Sheet>
+		<Sheet sx={{borderRight: openLineage ? '1px solid lightgrey' : undefined}}>
 			{!openLineage ?
 				(
 					<Button size="sm" sx={{m: '1rem'}} onClick={() => setOpenLineage(!openLineage)}>

--- a/src/components/ConfigExplorer/DataDisplayView.tsx
+++ b/src/components/ConfigExplorer/DataDisplayView.tsx
@@ -8,7 +8,9 @@ import ConfigurationTab from "./ConfigurationTab";
 import DescriptionTab from "./DescriptionTab";
 import { useParams } from "react-router-dom";
 import { ReactFlowProvider } from "react-flow-renderer";
-import { Sheet } from "@mui/joy";
+import { Button, Sheet } from "@mui/joy";
+import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
+import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
 
 export interface displayProps {
   data: any; // complete configuration
@@ -21,6 +23,7 @@ export default function DataDisplayView(props: displayProps) {
   const [configObj, setConfigObj] = React.useState();
   const [connectionConfigObj, setConnectionConfigObj] = React.useState();
   const [selectedTyp, setSelectedTab] = React.useState('description');
+  const [openLineage, setOpenLineage] = React.useState(false);
 
   React.useEffect(() => {
     if (elementType && elementName) {
@@ -36,49 +39,54 @@ export default function DataDisplayView(props: displayProps) {
   };
 
   return (
-	<Sheet
-		sx={{
-			display: 'flex',
-			width: '100%',
-			height: '86vh'
-		}}
-		>
-		<Sheet
-			sx={{
-				flex: 3,
-				overflow: 'auto',
-				py: '1rem',
-				pr: '1rem'		
-			}}
-		>
-			<TabContext value={selectedTyp}>
-    	  	<Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-    	  	  <Tabs value={selectedTyp} onChange={handleChange} aria-label="element tabs">
-    	  	    <Tab label="Description" value="description" sx={{height: "15px"}} />
-    	  	    <Tab label="Configuration" value="configuration" sx={{height: "15px"}} />
-    	  	   {/*  {(elementType==="actions" || elementType==="dataObjects") && <Tab label="Lineage" value="lineage" sx={{height: "15px"}} />} */}
-    	  	  </Tabs>
-    	  	</Box>
-    	  	<TabPanel value="description" className="content-panel">
-    	  	  <DescriptionTab elementName={elementName as string} data={configObj} elementType={elementType as string}/>
-    	  	</TabPanel>
-    	  	<TabPanel value="configuration" className="content-panel">
-    	  	  <ConfigurationTab data={configObj} elementName={elementName as string} elementType={elementType as string} connection={connectionConfigObj} />
-    	  	</TabPanel>
-    	  	{/* <TabPanel value="lineage" className="content-panel">
+	<Sheet sx={{display: 'flex', height: '100%', flex: 1, p: '1rem'}}>
+		<Sheet sx={{display: 'flex', flexDirection: 'column', flex: 2, overflowY: 'scroll', scrollbarWidth: 'none'}}>
 
-</TabPanel> */}
-    	</TabContext> 
+			<TabContext value={selectedTyp}>
+				<Sheet sx={{ display: 'flex', justifyContent: 'space-between', position: 'sticky'}}>
+					<Tabs value={selectedTyp} onChange={handleChange} aria-label="element tabs">
+						<Tab label="Description" value="description" />
+						<Tab label="Configuration" value="configuration" />
+					{/*  {(elementType==="actions" || elementType==="dataObjects") && <Tab label="Lineage" value="lineage" sx={{height: "15px"}} />} */}
+					</Tabs>
+				</Sheet>
+				<TabPanel value="description" className="content-panel">
+					<Sheet sx={{maxWidth: '75rem', flex: 1}}>
+						<DescriptionTab elementName={elementName as string} data={configObj} elementType={elementType as string}/>
+					</Sheet>
+				</TabPanel>
+				<TabPanel value="configuration" className="content-panel">
+					<Sheet sx={{width: 'auto', flex: 1, pr: '1rem'}}>
+					<ConfigurationTab data={configObj} elementName={elementName as string} elementType={elementType as string} connection={connectionConfigObj} />
+					</Sheet>
+				</TabPanel>
+			</TabContext> 
 		</Sheet>
+		<Sheet>
+			{!openLineage ?
+				(
+					<Button size="sm" sx={{m: '1rem'}} onClick={() => setOpenLineage(!openLineage)}>
+						Open lineage
+						<KeyboardDoubleArrowLeftIcon  sx={{ml: '0.5rem'}}/>
+					</Button>
+				) : (
+					<Button variant='soft' size="sm" sx={{m: '1rem'}} onClick={() => setOpenLineage(!openLineage)}>
+						Close lineage
+						<KeyboardDoubleArrowRightIcon  sx={{ml: '0.5rem'}}/>
+					</Button>
+				)}
+		</Sheet>
+		{openLineage &&
 		<Sheet
-			sx={{
-				flex: 2,
-			}}
+		sx={{
+			flex: 3,
+			height: '100%',
+		}}
 		>
 			<ReactFlowProvider>
 				<LineageTab data={props.data} elementName={elementName as string} elementType={elementType as string} />
 			</ReactFlowProvider>
-		</Sheet>
+		</Sheet>}
 	</Sheet>
   );
 } 

--- a/src/components/ConfigExplorer/DataDisplayView.tsx
+++ b/src/components/ConfigExplorer/DataDisplayView.tsx
@@ -43,38 +43,41 @@ export default function DataDisplayView(props: displayProps) {
 		<Sheet sx={{display: 'flex', flexDirection: 'column', flex: 2, overflowY: 'scroll', scrollbarWidth: 'none',  p: '1rem'}}>
 
 			<TabContext value={selectedTyp}>
-				<Sheet sx={{ display: 'flex', justifyContent: 'space-between', position: 'sticky'}}>
+				<Sheet sx={{ display: 'flex', justifyContent: 'space-between'}}>
 					<Tabs value={selectedTyp} onChange={handleChange} aria-label="element tabs">
 						<Tab label="Description" value="description" />
 						<Tab label="Configuration" value="configuration" />
 					{/*  {(elementType==="actions" || elementType==="dataObjects") && <Tab label="Lineage" value="lineage" sx={{height: "15px"}} />} */}
 					</Tabs>
+					<Sheet sx={{display: 'flex', alignItems: 'center'}}>
+						{!openLineage ?
+							(
+								<Button size="sm" onClick={() => setOpenLineage(!openLineage)}>
+									Open lineage
+									<KeyboardDoubleArrowLeftIcon  sx={{ml: '0.5rem'}}/>
+								</Button>
+							) : (
+								<Button variant='soft' size="sm" onClick={() => setOpenLineage(!openLineage)}>
+									Close lineage
+									<KeyboardDoubleArrowRightIcon  sx={{ml: '0.5rem'}}/>
+								</Button>
+						)}
+					</Sheet>
 				</Sheet>
 				<TabPanel value="description" className="content-panel">
-					<Sheet sx={{maxWidth: '75rem', flex: 1}}>
+					<Sheet sx={{maxWidth: '100rem', flex: 1}}>
 						<DescriptionTab elementName={elementName as string} data={configObj} elementType={elementType as string}/>
 					</Sheet>
 				</TabPanel>
 				<TabPanel value="configuration" className="content-panel">
-					<Sheet sx={{width: 'auto', flex: 1, pr: '1rem'}}>
+					<Sheet sx={{width: 'auto', flex: 1}}>
 					<ConfigurationTab data={configObj} elementName={elementName as string} elementType={elementType as string} connection={connectionConfigObj} />
 					</Sheet>
 				</TabPanel>
 			</TabContext> 
 		</Sheet>
 		<Sheet sx={{borderRight: openLineage ? '1px solid lightgrey' : undefined}}>
-			{!openLineage ?
-				(
-					<Button size="sm" sx={{m: '1rem'}} onClick={() => setOpenLineage(!openLineage)}>
-						Open lineage
-						<KeyboardDoubleArrowLeftIcon  sx={{ml: '0.5rem'}}/>
-					</Button>
-				) : (
-					<Button variant='soft' size="sm" sx={{m: '1rem'}} onClick={() => setOpenLineage(!openLineage)}>
-						Close lineage
-						<KeyboardDoubleArrowRightIcon  sx={{ml: '0.5rem'}}/>
-					</Button>
-				)}
+			
 		</Sheet>
 		{openLineage &&
 		<Sheet

--- a/src/components/ConfigExplorer/ElementList.tsx
+++ b/src/components/ConfigExplorer/ElementList.tsx
@@ -124,7 +124,7 @@ export default function ElementList(props: ElementListProps) {
 
 
   return (
-    <Box sx={{"overflowX": "clip", width: '17rem', height: '85vh', pt:'1rem', borderRight: '1px solid lightgray'}}>
+    <Box sx={{width: '17rem', height: '85vh', pt:'1rem', borderRight: '1px solid lightgray'}}>
       <TextField
         className="search_field"
         variant="outlined"

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import OpenWithIcon from '@mui/icons-material/OpenWith';
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
 import DownloadButton from './DownloadLineageButton';
+import { Lineage } from '../../util/WorkflowsExplorer/Lineage';
 
 
 
@@ -67,6 +68,7 @@ function createReactFlowNodes_Old(dataObjectsAndActions: DAGraph){
 function createReactFlowEdges(dataObjectsAndActions: DAGraph){
   var result: any[] = [];
   dataObjectsAndActions.edges.forEach(edge => {
+    console.log(edge)
     //const action = edge as Action; //downcasting in order to access jsonObject
     const action = edge; //downcasting in order to access jsonObject
     result.push({
@@ -88,10 +90,10 @@ function createReactFlowEdges(dataObjectsAndActions: DAGraph){
 
 
 interface flowProps {
-  dataSource: 'config' | 'statefiles',
+  elementName: string,
+  elementType: string,
   data?: object,
-  elementName?: string,
-  elementType?: string,
+  graph?: PartialDataObjectsAndActions, 
   runContext?: boolean,
 }
 
@@ -100,10 +102,10 @@ type flowNodeWithString = Node<any> & {jsonString?:string} //merge Node type of 
 type flowEdgeWithString = Edge<any> & {jsonString?:string} & {old_id?: string}
 
 
-
 function LineageTab(props: flowProps) {
+  console.log(typeof props.data)
 
-  const doa = new DataObjectsAndActions(props.data);
+  const doa = props.graph ? props.graph : new DataObjectsAndActions(props.data);
   let nodes_init: any[] = [];
   let edges_init: any[] = [];
   const [onlyDirectNeighbours, setOnlyDirectNeighbours] = useState([true, 'Expand Graph']);

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -59,6 +59,7 @@ function createReactFlowNodes_Old(dataObjectsAndActions: DAGraph){
         type: nodeType,
         position: {x: pos_x, y: pos_y},
         data: { label: dataObjectsInLevel[i].id },
+        style: {onclick: () => console.log("hello")},
         //jsonString: JSON.stringify(dataObjectsInLevel[i].jsonObject , null, '\t'),
       });
     }
@@ -82,9 +83,9 @@ function createReactFlowEdges(dataObjectsAndActions: DAGraph){
       label_copy: action.id,
       labelBgPadding: [7, 7],
       labelBgBorderRadius: 8,
-      labelBgStyle: { fill: '#ffd796', color: '#FFF', fillOpacity: 1, stroke: '#ed7b24' },
+      labelBgStyle: { fill: '#fff', fillOpacity: 1, stroke: '#ed7b24' },
       //jsonString: JSON.stringify(action.jsonObject, null, '\t'),
-      style: { stroke: '#096bde', strokeWidth: 2, hover: { backgroundColor: 'gold' }},
+      style: { stroke: '#096bde', strokeWidth: 2},
       // type: 'runLineage',
     });
   });
@@ -175,7 +176,6 @@ function LineageTab(props: flowProps) {
   const hide = (hidden: boolean) => (edge: any) => {
     if (hidden){
       edge.label = '';
-      edge.markerEnd = {type: MarkerType.ArrowClosed, color: 'red', width: 20, height: 20};
     }else{
       edge.label = edge.label_copy;
       edge.markerEnd = {};
@@ -218,12 +218,16 @@ function LineageTab(props: flowProps) {
   const navigate = useNavigate();   
   function clickOnNode(node: flowNodeWithString){
     //renderPartialGraph(node.id); //DEPRECATED WAY OF SHOWING PARTIAL GRAPHS
-    if (props.data) navigate(`/config/dataObjects/${node.id}`); //Link programmatically
-  }
-  
+    if (props.data) {
+      navigate(`/config/dataObjects/${node.id}`); //Link programmatically
+    }
+  } 
   function clickOnEdge(edge: flowEdgeWithString){
-    if (props.data) navigate(`/config/actions/${edge.old_id}`); //Link programmatically
-    navigate(`/workflows/${url.flowId}/${url.runNumber}/${url.taskId}/${url.tab}/${edge.old_id}`);
+    if (props.data) { 
+      navigate(`/config/actions/${edge.old_id}`); //Link programmatically
+    } else {
+      navigate(`/workflows/${url.flowId}/${url.runNumber}/${url.taskId}/${url.tab}/${edge.old_id}`);
+    }
   }
 
   // container holding SVG needs manual height resizing to fill 100%

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -10,6 +10,8 @@ import OpenWithIcon from '@mui/icons-material/OpenWith';
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
 import DownloadButton from './DownloadLineageButton';
 import { Lineage } from '../../util/WorkflowsExplorer/Lineage';
+import Run from '../WorkflowsExplorer/Run/Run';
+import RunLineageEdge from '../WorkflowsExplorer/Run/RunLineageEdge';
 
 
 
@@ -82,8 +84,8 @@ function createReactFlowEdges(dataObjectsAndActions: DAGraph){
       labelBgBorderRadius: 8,
       labelBgStyle: { fill: '#ffd796', color: '#FFF', fillOpacity: 1, stroke: '#ed7b24' },
       //jsonString: JSON.stringify(action.jsonObject, null, '\t'),
-      style: { stroke: '#096bde', strokeWidth: 2},
-      selected: () => {console.log('mouse over')},
+      style: { stroke: '#096bde', strokeWidth: 2, hover: { backgroundColor: 'gold' }},
+      // type: 'runLineage',
     });
   });
   return result;
@@ -101,6 +103,10 @@ interface flowProps {
 type flowNodeWithString = Node<any> & {jsonString?:string} //merge Node type of ReactFlow with an (optional) String attribute. 
 
 type flowEdgeWithString = Edge<any> & {jsonString?:string} & {old_id?: string}
+
+const edgeTypes = {
+  runLineage: RunLineageEdge,
+}
 
 
 function LineageTab(props: flowProps) {
@@ -260,6 +266,7 @@ function LineageTab(props: flowProps) {
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         nodesConnectable={false} //prevents adding new edges
+        //edgeTypes={edgeTypes}
       >
         <Background />
         <MiniMap />
@@ -286,7 +293,6 @@ function LineageTab(props: flowProps) {
           <DownloadButton />
         </div>
         </Box>
-
       </ReactFlow>
     </Box>
   );

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -68,7 +68,6 @@ function createReactFlowNodes_Old(dataObjectsAndActions: DAGraph){
 function createReactFlowEdges(dataObjectsAndActions: DAGraph){
   var result: any[] = [];
   dataObjectsAndActions.edges.forEach(edge => {
-    console.log(edge)
     //const action = edge as Action; //downcasting in order to access jsonObject
     const action = edge; //downcasting in order to access jsonObject
     result.push({
@@ -79,10 +78,12 @@ function createReactFlowEdges(dataObjectsAndActions: DAGraph){
       //animated: true, 
       label: action.id,
       label_copy: action.id,
-      labelBgPadding: [8, 4],
-      labelBgStyle: { fill: action.isCentral ? '#096bde' : '#ffffff', color: '#FFF', fillOpacity: 0.7 },
+      labelBgPadding: [7, 7],
+      labelBgBorderRadius: 8,
+      labelBgStyle: { fill: '#ffd796', color: '#FFF', fillOpacity: 1, stroke: '#ed7b24' },
       //jsonString: JSON.stringify(action.jsonObject, null, '\t'),
-      style: { stroke: '#096bde' },
+      style: { stroke: '#096bde', strokeWidth: 2},
+      selected: () => {console.log('mouse over')},
     });
   });
   return result;
@@ -103,7 +104,7 @@ type flowEdgeWithString = Edge<any> & {jsonString?:string} & {old_id?: string}
 
 
 function LineageTab(props: flowProps) {
-  console.log(typeof props.data)
+  const url = useParams();
 
   const doa = props.graph ? props.graph : new DataObjectsAndActions(props.data);
   let nodes_init: any[] = [];
@@ -211,11 +212,12 @@ function LineageTab(props: flowProps) {
   const navigate = useNavigate();   
   function clickOnNode(node: flowNodeWithString){
     //renderPartialGraph(node.id); //DEPRECATED WAY OF SHOWING PARTIAL GRAPHS
-    navigate(`/config/dataObjects/${node.id}`); //Link programmatically
+    if (props.data) navigate(`/config/dataObjects/${node.id}`); //Link programmatically
   }
-
+  
   function clickOnEdge(edge: flowEdgeWithString){
-    navigate(`/config/actions/${edge.old_id}`); //Link programmatically
+    if (props.data) navigate(`/config/actions/${edge.old_id}`); //Link programmatically
+    navigate(`/workflows/${url.flowId}/${url.runNumber}/${url.taskId}/${url.tab}/${edge.old_id}`);
   }
 
   // container holding SVG needs manual height resizing to fill 100%
@@ -227,7 +229,6 @@ function LineageTab(props: flowProps) {
   function handleResize() {
     if (chartBox.current) {
       const height = window.innerHeight - chartBox.current.offsetTop - 25; // 25px bottom margin...
-      console.log('resized to: ', height);
       setContentHeight(height);
     }
   }
@@ -263,7 +264,9 @@ function LineageTab(props: flowProps) {
         <Background />
         <MiniMap />
         <Controls />
-        <div title='Display / Hide action IDs' style={{ position: 'absolute', left: 9, bottom: 125, zIndex: 4, cursor: 'pointer' }}>
+        <Box sx={{position: 'absolute', left: 9, bottom: 135, display: 'flex', flexDirection: 'column-reverse'}}>
+
+        <div title='Display / Hide action IDs' style={{ zIndex: 4, cursor: 'pointer' }}>
           <IconButton 
             color={hidden ? 'inherit' : 'primary'}
             onClick={() => setHidden(!hidden)}>
@@ -271,17 +274,18 @@ function LineageTab(props: flowProps) {
           </IconButton>
         </div>
 
-        <div title={onlyDirectNeighbours[1] as string} style={{ position: 'absolute', left: 9, bottom: 155, zIndex: 4, cursor: 'pointer' }}>
+        {props.data && <div title={onlyDirectNeighbours[1] as string} style={{  zIndex: 4, cursor: 'pointer' }}>
           <IconButton 
             color='inherit'
             onClick={expandGraph}>
             {onlyDirectNeighbours[0] ? <OpenWithIcon/> : <CloseFullscreenIcon/>}
           </IconButton>
-        </div>
+        </div>}
 
-        <div title='Download image as PNG file' style={{ position: 'absolute', left: 9, bottom: 185, zIndex: 4, cursor: 'pointer' }}>
+        <div title='Download image as PNG file' style={{ zIndex: 4, cursor: 'pointer' }}>
           <DownloadButton />
         </div>
+        </Box>
 
       </ReactFlow>
     </Box>

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -88,9 +88,10 @@ function createReactFlowEdges(dataObjectsAndActions: DAGraph){
 
 
 interface flowProps {
-  data: object,
-  elementName: string,
-  elementType: string,
+  dataSource: 'config' | 'statefiles',
+  data?: object,
+  elementName?: string,
+  elementType?: string,
   runContext?: boolean,
 }
 

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -162,8 +162,6 @@ function LineageTab(props: flowProps) {
   const [edges, setEdges] = useState(initial_render[0]);
   let [hidden, setHidden] = useState(useParams().elementType === 'dataObjects' ? true : false); //Hidden action labels
 
-
-
   const hide = (hidden: boolean) => (edge: any) => {
     if (hidden){
       edge.label = '';
@@ -180,7 +178,6 @@ function LineageTab(props: flowProps) {
     setEdges((eds) => eds.map(hide(hidden)));
   }, [hidden, onlyDirectNeighbours]); //edges must be hidden at each render (that is, also when we expand/compress the graph)
 
-
   //DEPRECATED
   function renderPartialGraph(nodeId: string){
 
@@ -196,14 +193,11 @@ function LineageTab(props: flowProps) {
     setEdges(newEdges);
   }
 
-
-
   //Nodes and edges can be moved. Used "any" type as first, non-clean implementation. 
   const onNodesChange = useCallback(
     (changes: any) => setNodes((nds: any) => applyNodeChanges(changes, nds)),
     [setNodes]
   );
-
   
   const onEdgesChange = useCallback(
     (changes: any) => setEdges((eds: any) => applyEdgeChanges(changes, eds)),
@@ -216,6 +210,7 @@ function LineageTab(props: flowProps) {
     //renderPartialGraph(node.id); //DEPRECATED WAY OF SHOWING PARTIAL GRAPHS
     navigate(`/config/dataObjects/${node.id}`); //Link programmatically
   }
+
   function clickOnEdge(edge: flowEdgeWithString){
     navigate(`/config/actions/${edge.old_id}`); //Link programmatically
   }
@@ -223,7 +218,6 @@ function LineageTab(props: flowProps) {
   // container holding SVG needs manual height resizing to fill 100%
   const chartBox = useRef<HTMLDivElement>();
   const [contentHeight, setContentHeight] = useState(100);
-
 
   const reactFlow = useReactFlow();
 
@@ -243,8 +237,6 @@ function LineageTab(props: flowProps) {
     }, 1);
     window.addEventListener('resize', () => handleResize());
   }
-
-
 
   return (
     <Box 

--- a/src/components/ConfigExplorer/MarkdownComponent.tsx
+++ b/src/components/ConfigExplorer/MarkdownComponent.tsx
@@ -4,12 +4,8 @@ import remarkGfm from 'remark-gfm';
 
 export default function MarkdownComponent(props: {markdown: string}){
   return (
-    <Sheet
-      sx={{
-        width: '100%'
-      }}
-    >
+    <>
       <ReactMarkdown className='markdown-body' children={props.markdown} remarkPlugins={[remarkGfm]} />
-    </Sheet>
+    </>
   )
 }

--- a/src/components/WorkflowsExplorer/Run/ContentDrawer.tsx
+++ b/src/components/WorkflowsExplorer/Run/ContentDrawer.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Sheet, Table, Tooltip, Typography } from "@mui/joy";
+import { Box, Button, IconButton, Sheet, Table, Tooltip, Typography } from "@mui/joy";
 import CloseIcon from '@mui/icons-material/Close';
 import { useNavigate, useParams } from "react-router-dom";
 import Attempt from "../../../util/WorkflowsExplorer/Attempt";
@@ -77,75 +77,75 @@ const ContentSheet = (props: {action: Row}) => {
     const { action } = props;
     
     return (
-        <>
-                {action.metadata.map((meta) => {
-                    const toDisplay : any[] = [];
-                    if (meta.mainMetrics) {
+        <Sheet>
+            {action.metadata.map((meta) => {
+                const toDisplay : any[] = [];
+                if (meta.mainMetrics) {
+                    toDisplay.push(
+                        <Box 
+                        key='meta.mainMetrics'
+                        sx={{mb: '1.5rem'}}
+                        >
+                                <Typography noWrap level='h5'>
+                                    Main metrics
+                                </Typography>
+                                <ResultsTable metrics={meta.mainMetrics}/>
+                            </Box>
+                        )
+                    } 
+                    if (meta.subFeed) {
                         toDisplay.push(
                             <Box 
-                            key='meta.mainMetrics'
-                            sx={{mb: '1.5rem'}}
+                            key='meta.subFeed'
                             >
-                                    <Typography noWrap level='h5'>
-                                        Main metrics
-                                    </Typography>
-                                    <ResultsTable metrics={meta.mainMetrics}/>
-                                </Box>
-                            )
-                        } 
-                        if (meta.subFeed) {
-                            toDisplay.push(
-                                <Box 
-                                key='meta.subFeed'
-                                >
-                                    <Typography noWrap level='h5'>
-                                        Subfeed
-                                    </Typography>
-                                    <ResultsTable subFeed={meta.subFeed}/>
-                                </Box>
-                            )
-                        } 
-                        if (!meta.mainMetrics && !meta.subFeed) {
-                            toDisplay.push(
-                                <Typography noWrap level='h5' key='noData'>
-                                    Error: found no metadata to display
+                                <Typography noWrap level='h5'>
+                                    Subfeed
                                 </Typography>
-                            )
-                        }
-                        return (
-                            <Sheet 
-                            color="neutral" 
-                            variant="outlined"
-                            key='resultSheet'
-                            sx={{
-                                p: '1rem',
-                                mt: '1rem',
-                                borderRadius: '0.5rem',
-                                height: 'auto',
-                            }}>
-                                {toDisplay}
-                            </Sheet>
+                                <ResultsTable subFeed={meta.subFeed}/>
+                            </Box>
                         )
-                    })
-                }
-                {action.message && <Sheet 
-                    color="info" 
-                    variant="soft"
-                    key='resultSheet'
-                    invertedColors
-                    sx={{
-                        p: '1rem',
-                        mt: '1rem',
-                        borderRadius: '0.5rem',
-                    }}>
-                    <Typography color="info" level='body2'>
-                        Info:
-                    </Typography>
-                    <code>
-                        {action.message}
-                    </code>
-                </Sheet>}
-                </>
+                    } 
+                    if (!meta.mainMetrics && !meta.subFeed) {
+                        toDisplay.push(
+                            <Typography noWrap level='h5' key='noData'>
+                                Error: found no metadata to display
+                            </Typography>
+                        )
+                    }
+                    return (
+                        <Sheet 
+                        color="neutral" 
+                        variant="outlined"
+                        key='resultSheet'
+                        sx={{
+                            p: '1rem',
+                            mt: '1rem',
+                            borderRadius: '0.5rem',
+                            height: 'auto',
+                        }}>
+                            {toDisplay}
+                        </Sheet>
+                    )
+                })
+            }
+            {action.message && <Sheet 
+                color="info" 
+                variant="soft"
+                key='resultSheet'
+                invertedColors
+                sx={{
+                    p: '1rem',
+                    mt: '1rem',
+                    borderRadius: '0.5rem',
+                }}>
+                <Typography color="info" level='body2'>
+                    Info:
+                </Typography>
+                <code>
+                    {action.message}
+                </code>
+            </Sheet>}
+        </Sheet>
     )
 }
 
@@ -165,10 +165,9 @@ const ContentDrawer = (props: {attempt: Attempt}) => {
         <Sheet
             sx={{
                 p: '1rem',
-                pl: '1.5rem',
-                height: '70vh',
                 display: 'flex',
                 flexDirection: 'column',
+                height: '100%'
             }}
             >
             
@@ -196,13 +195,18 @@ const ContentDrawer = (props: {attempt: Attempt}) => {
             </Box>
             <Box
                 sx={{
-                    overflowY: 'scroll',
-                    scrollbarWidth: 'none',
-                    overflowX: 'hidden',
-                    pr: '1rem',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '1rem',
+                    height: '100%',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-end',
                 }}
             >
-                <ContentSheet action={action}/>
+                <Box>
+                    <ContentSheet action={action}/>
+                </Box>
+                <Button size="sm" variant="solid">Open in Config Viewer</Button>
             </Box>
         </Sheet>
      );

--- a/src/components/WorkflowsExplorer/Run/ContentDrawer.tsx
+++ b/src/components/WorkflowsExplorer/Run/ContentDrawer.tsx
@@ -155,12 +155,23 @@ const ContentSheet = (props: {action: Row}) => {
  * @param props attempt: Attempt
  * @returns 
  */
-const ContentDrawer = (props: {attempt: Attempt}) => {
-    const { attempt } = props;
+const ContentDrawer = (props: {attempt: Attempt, configData: any}) => {
+    const { attempt, configData } = props;
     const { flowId, runNumber, taskId, tab, stepName } = useParams();
     const navigate = useNavigate();
     const action : Row = getRow(attempt, stepName || 'err');
     
+    const isActionInConfig = () => {
+        const allActions = Object.keys(configData.actions).sort();
+        const isIn = allActions.includes(action.step_name);
+        console.log(isIn);
+        return isIn;
+    }
+
+    const handleClick = () => {
+        navigate(`/config/actions/${action.step_name}`);
+    }
+
     return ( 
         <Sheet
             sx={{
@@ -206,7 +217,7 @@ const ContentDrawer = (props: {attempt: Attempt}) => {
                 <Box>
                     <ContentSheet action={action}/>
                 </Box>
-                <Button size="sm" variant="solid">Open in Config Viewer</Button>
+                <Button disabled={!isActionInConfig()} onClick={() => handleClick() } size="sm" variant="solid">Open in Config Viewer</Button>
             </Box>
         </Sheet>
      );

--- a/src/components/WorkflowsExplorer/Run/Run.tsx
+++ b/src/components/WorkflowsExplorer/Run/Run.tsx
@@ -14,7 +14,7 @@ import { displayProps } from "../../ConfigExplorer/DataDisplayView";
     @param {boolean} props.panelOpen - Indicates whether the details panel is open or not.
     @returns {JSX.Element} - The Run component UI.
 */
-const Run = (props : {panelOpen?: boolean, lineageData: displayProps}) => {
+const Run = (props : {panelOpen?: boolean, configData: displayProps}) => {
     const links = [...useLocation().pathname.split('/')].splice(1);
     const { data, isLoading, isFetching } = useFetchRun(links[1], parseInt(links[2]), parseInt(links[3]));
 
@@ -25,7 +25,7 @@ const Run = (props : {panelOpen?: boolean, lineageData: displayProps}) => {
         <>
             <PageHeader title= {attempt.runInfo.workflowName + ': run ' + attempt.runInfo.runId} />
             {/* <RunDetails attempt={attempt}/> */}
-            <TabNav attempt={attempt} panelOpen={props.panelOpen} lineageData={props.lineageData}/>
+            <TabNav attempt={attempt} panelOpen={props.panelOpen} configData={props.configData}/>
         </>
     );
 }

--- a/src/components/WorkflowsExplorer/Run/RunLineageEdge.tsx
+++ b/src/components/WorkflowsExplorer/Run/RunLineageEdge.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react';
+import EdgeLabelRenderer, {EdgeProps, getBezierPath } from 'react-flow-renderer';
+import BaseEdge from 'react-flow-renderer';
+
+const RunLineageEdge: FC<EdgeProps> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}) => {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+        <BaseEdge/>
+    </>
+  );
+};
+
+export default RunLineageEdge;

--- a/src/components/WorkflowsExplorer/Run/Tabs.tsx
+++ b/src/components/WorkflowsExplorer/Run/Tabs.tsx
@@ -281,7 +281,7 @@ const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?
                         </TabList>
                         {!openLineage ?
                             (
-                                <IconButton color={'primary'} size="md" variant="solid" sx={{ml: '1rem', px: '1rem', scale: '80%'}} onClick={() => setOpenLineage(!openLineage)}>
+                                <IconButton disabled={attempt.rows[0].inputIds ? false : true} color={'primary'} size="md" variant="solid" sx={{ml: '1rem', px: '1rem', scale: '80%'}} onClick={() => setOpenLineage(!openLineage)}>
                                     Open lineage
                                     <KeyboardDoubleArrowLeftIcon  sx={{ml: '0.5rem'}}/>
                                 </IconButton>
@@ -301,14 +301,7 @@ const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?
                     <Sheet sx={{borderLeft: '1px solid lightgray', mx: '1rem'}}/>
                     <Sheet sx={{width: '40%', flex: 2}}>
                         <ReactFlowProvider>
-                            <ReactFlow 
-                                nodes={graph.nodes} 
-                                edges={graph.edges}
-                                defaultPosition={[0,0]}     
-                            >
-                                <Background />
-                                <Controls />
-                            </ReactFlow>
+                            <LineageTab graph={graph} elementName="" elementType=""/>
                         </ReactFlowProvider>
                     </Sheet>
                 </>

--- a/src/components/WorkflowsExplorer/Run/Tabs.tsx
+++ b/src/components/WorkflowsExplorer/Run/Tabs.tsx
@@ -115,7 +115,7 @@ const TabsPanels = (props : {attempt: Attempt, open?: boolean}) => {
                             gap: '5rem',
                             border: '1px solid lightgray',
                             borderRadius: '0.5rem',
-                            height: '67vh',
+                            height: '100%',
                         }}
                     >
                         <InboxIcon
@@ -263,7 +263,7 @@ const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?
         <Sheet sx={{display: 'flex', height: '86vh'}}>
             <Sheet 
                 sx={{
-                    flex: 3,
+                    flex: 1,
                 }}
             >
                 <Tabs aria-label="Basic tabs" defaultValue={value} onChange={(e, v) => handleChange(e, v)}>
@@ -299,7 +299,7 @@ const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?
             {openLineage && (
                 <>
                     <Sheet sx={{borderLeft: '1px solid lightgray', mx: '1rem'}}/>
-                    <Sheet sx={{width: '40%', flex: 2}}>
+                    <Sheet sx={{width: '40%', flex: 1}}>
                         <ReactFlowProvider>
                             <LineageTab graph={graph} elementName="" elementType=""/>
                         </ReactFlowProvider>

--- a/src/components/WorkflowsExplorer/Run/Tabs.tsx
+++ b/src/components/WorkflowsExplorer/Run/Tabs.tsx
@@ -43,8 +43,8 @@ export const defaultDrawerWidth = 600;
  * @param {boolean} props.open - Determines whether or not the content drawer is open for the timeline and actions table components 
  * @returns A set of three React components (ToolBar, Tabs, TabPanel) rendered inside a parent component.
  */
-const TabsPanels = (props : {attempt: Attempt, open?: boolean}) => {
-    const { attempt, open } = props;
+const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolean}) => {
+    const { attempt, open, configData } = props;
     const defaultRows = attempt.rows;
     const [rows, setRows] = useState<Row[]>(defaultRows);
     const [checked, setChecked] = useState([
@@ -217,7 +217,7 @@ const TabsPanels = (props : {attempt: Attempt, open?: boolean}) => {
                             boxShadow: '-10px 10px 10px lightgray',
                         }}
                     >
-                        <ContentDrawer attempt={attempt}/>
+                        <ContentDrawer attempt={attempt} configData={configData}/>
                     </Sheet>
                 </>
             )}
@@ -230,11 +230,11 @@ const TabsPanels = (props : {attempt: Attempt, open?: boolean}) => {
  * @param props {attempt: Attempt, panelOpen?: boolean}
  * @returns JSX.Element
  */
-const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?: boolean}) => {
+const TabNav = (props : {attempt: Attempt, configData: displayProps, panelOpen?: boolean}) => {
     const { stepName, tab } = useParams();
     const [value, setValue] = React.useState(tab === 'timeline' ? 0: 1);
     const [openLineage, setOpenLineage] = useState<boolean>(false);
-    const { attempt, panelOpen } = props;
+    const { attempt, panelOpen, configData } = props;
     const navigate =  useNavigate();
 
     const handleChange = (_e : any, v: any) => {
@@ -266,7 +266,7 @@ const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?
                     flex: 1,
                 }}
             >
-                <Tabs aria-label="Basic tabs" defaultValue={value} onChange={(e, v) => handleChange(e, v)}>
+                <Tabs aria-label="Basic tabs" defaultValue={value} onChange={(e, v) => handleChange(e, v)} >
                     <Box
                         sx={{
                             display: 'flex',
@@ -293,7 +293,7 @@ const TabNav = (props : {attempt: Attempt, lineageData: displayProps, panelOpen?
                             )
                         }
                     </Box>
-                    <TabsPanels attempt={attempt} open = {panelOpen}/>
+                    <TabsPanels attempt={attempt} open = {panelOpen} configData={configData}/>
                 </Tabs>
             </Sheet>
             {openLineage && (

--- a/src/components/WorkflowsExplorer/ToolBar/Phases.tsx
+++ b/src/components/WorkflowsExplorer/ToolBar/Phases.tsx
@@ -26,7 +26,6 @@ const Phases = (props: {updatePhases: (phases: {name: string, checked: boolean}[
     };
 
     useEffect(() => {
-        console.log(phases);
         updatePhases(phases);
     }, [phases])
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,12 +15,17 @@ import { QueryClient, QueryClientProvider } from "react-query";
 // react 18
 const rootElement = document.getElementById("root");
 const root = ReactDOMClient.createRoot(rootElement as HTMLElement);
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false, // default: true
+    },
+  },
+});
 root.render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-
-    <App />
+      <App />
     </QueryClientProvider>
   </StrictMode>
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,8 +65,8 @@ export class Row implements MetaDataBaseObject {
     endTstmpPrepare?: number;
     startTstmpInit? : number;
     endTstmpInit?: number;
-    inputId?: string[];
-    outputId?: string[];
+    inputIds?: {id: string}[];
+    outputIds?: {id: string}[];
    
     constructor({ properties }: { properties: TaskProperty; }) {
       this.flow_id = properties.runInfo.workflowName;
@@ -88,8 +88,8 @@ export class Row implements MetaDataBaseObject {
       this.endTstmpPrepare = properties.action.endTstmpPrepare ? new Date(properties.action.endTstmpPrepare).getTime() : undefined;
       this.startTstmpInit = properties.action.startTstmpInit ? new Date(properties.action.startTstmpInit).getTime() : undefined;
       this.endTstmpInit = properties.action.endTstmpInit ? new Date(properties.action.endTstmpInit).getTime() : undefined;
-      this.inputId = properties.action.inputId;
-      this.outputId = properties.action.outputId;
+      this.inputIds = properties.action.inputIds;
+      this.outputIds = properties.action.outputIds;
     }
 
     /**
@@ -173,8 +173,8 @@ export class Row implements MetaDataBaseObject {
     endTstmpPrepare?: string,
     startTstmpInit? : string,
     endTstmpInit?: string,
-    inputId?: string[],
-    outputId?: string[],
+    inputIds?: {id: string}[],
+    outputIds?: {id: string}[],
   }
   export type Metadata = [{
     subFeed?: {

--- a/src/util/ConfigExplorer/Graphs.ts
+++ b/src/util/ConfigExplorer/Graphs.ts
@@ -27,7 +27,7 @@ type position = {
     y: number
 }
 
-class Node{
+export class Node{
     public id: id;
     public position: position;
     public width: number;
@@ -35,31 +35,36 @@ class Node{
     public level: number;
     public backgroundColor: string;
     public isCenterNode: boolean;
+    public data: {id: string};
 
-    constructor(id: id, level: number = -1){
+    constructor(id: id, position?: {x: number, y: number}, level: number = -1){
         this.id = id;
         this.level = level //level defines the longest path starting from all input nodes
-        this.position = {x:0, y:0};
+        this.position = position ? position : {x:0, y:0};
         this.width = 172;
         this.height = 36;
         this.backgroundColor = '#FFFFFF';
         this.isCenterNode = false;
+        this.data = {id: this.id}
     }
 } 
 
-class Edge{
+export class Edge{
 
     public fromNode: Node;
     public toNode: Node;
     public id: id;
     public isCentral: boolean;
+    public source: string;
+    public target: string;
 
     constructor(fromNode: Node, toNode: Node, id: id){
         this.fromNode = fromNode;
         this.toNode = toNode;
         this.id = id; //Ids are not unique identifiers, since we can have the same Edge/Action connecting several Nodes/DataObjects.
         this.isCentral = false;
-
+        this.source = this.fromNode.id;
+        this.target = this.toNode.id;
     }
 }
 

--- a/src/util/ConfigExplorer/Graphs.ts
+++ b/src/util/ConfigExplorer/Graphs.ts
@@ -282,7 +282,7 @@ function getActions(actionsJSON: any, dataObjects: any){
 }
 
 
-function computeNodePositions(nodes: Node[], edges: Edge[]){
+export function computeNodePositions(nodes: Node[], edges: Edge[]){
     //instantiate dagre Graph
     const dagreGraph = new dagre.graphlib.Graph();
     dagreGraph.setGraph({});

--- a/src/util/ConfigExplorer/Graphs.ts
+++ b/src/util/ConfigExplorer/Graphs.ts
@@ -57,14 +57,16 @@ export class Edge{
     public isCentral: boolean;
     public source: string;
     public target: string;
+    public type?: string;
 
-    constructor(fromNode: Node, toNode: Node, id: id){
+    constructor(fromNode: Node, toNode: Node, id: id, type?: string){
         this.fromNode = fromNode;
         this.toNode = toNode;
         this.id = id; //Ids are not unique identifiers, since we can have the same Edge/Action connecting several Nodes/DataObjects.
         this.isCentral = false;
         this.source = this.fromNode.id;
         this.target = this.toNode.id;
+        this.type = type;
     }
 }
 

--- a/src/util/WorkflowsExplorer/Lineage.ts
+++ b/src/util/WorkflowsExplorer/Lineage.ts
@@ -26,7 +26,6 @@ export class Lineage {
         data.forEach(fromNode => {
             fromNode.edges.forEach(toNode => {
                 edges.push(new Edge(fromNode.node, toNode.to, toNode.id))
-                console.log(toNode.id)
             })
         })
 

--- a/src/util/WorkflowsExplorer/Lineage.ts
+++ b/src/util/WorkflowsExplorer/Lineage.ts
@@ -1,4 +1,4 @@
-import { Node, Edge, DAGraph } from '../ConfigExplorer/Graphs'
+import { Node, Edge, DAGraph, computeNodePositions } from '../ConfigExplorer/Graphs'
 
 export class Lineage {
     lineageData: any;
@@ -6,7 +6,10 @@ export class Lineage {
 
     constructor(data: {action: string, inputIds: {id: string}[], outputIds: {id: string}[]}[]) {
         const preprocessedData: {id: string, node: Node, edges: {id: string, to: Node}[]}[] = this.prepareGraphData(data)
-        this.graph = new DAGraph(this.getNodes(preprocessedData), this.getEdges(preprocessedData))
+        const nodes = this.getNodes(preprocessedData);
+        const edges = this.getEdges(preprocessedData);
+
+        this.graph = new DAGraph(computeNodePositions(nodes, edges), edges)
     }
 
     getNodes = (data: {id: string, node: Node, edges: {id: string, to: Node}[]}[]) => {
@@ -42,10 +45,8 @@ export class Lineage {
             });
         });
 
-        let py = 0;
         nodes.forEach(node => {
-            graph.push({id: node, node: new Node(node, {y: py, x: 0}), edges: []})
-            py = py+50
+            graph.push({id: node, node: new Node(node, {y: 0, x: 0}), edges: []})
         })
 
         nodes.forEach(node => {
@@ -64,7 +65,6 @@ export class Lineage {
             })
         })
 
-        console.log(graph)
         return graph
     }
 }

--- a/src/util/WorkflowsExplorer/Lineage.ts
+++ b/src/util/WorkflowsExplorer/Lineage.ts
@@ -1,4 +1,4 @@
-import { Node, Edge, DAGraph, computeNodePositions } from '../ConfigExplorer/Graphs'
+import { Node, Edge, DAGraph, computeNodePositions, PartialDataObjectsAndActions } from '../ConfigExplorer/Graphs'
 
 export class Lineage {
     lineageData: any;
@@ -9,7 +9,7 @@ export class Lineage {
         const nodes = this.getNodes(preprocessedData);
         const edges = this.getEdges(preprocessedData);
 
-        this.graph = new DAGraph(computeNodePositions(nodes, edges), edges)
+        this.graph = new PartialDataObjectsAndActions(nodes, edges)
     }
 
     getNodes = (data: {id: string, node: Node, edges: {id: string, to: Node}[]}[]) => {
@@ -25,7 +25,8 @@ export class Lineage {
         let edges : Edge[] = [];
         data.forEach(fromNode => {
             fromNode.edges.forEach(toNode => {
-                edges.push(new Edge(fromNode.node, toNode.to, fromNode.id))
+                edges.push(new Edge(fromNode.node, toNode.to, toNode.id))
+                console.log(toNode.id)
             })
         })
 

--- a/src/util/WorkflowsExplorer/Lineage.ts
+++ b/src/util/WorkflowsExplorer/Lineage.ts
@@ -1,0 +1,70 @@
+import { Node, Edge, DAGraph } from '../ConfigExplorer/Graphs'
+
+export class Lineage {
+    lineageData: any;
+    graph: DAGraph;
+
+    constructor(data: {action: string, inputIds: {id: string}[], outputIds: {id: string}[]}[]) {
+        const preprocessedData: {id: string, node: Node, edges: {id: string, to: Node}[]}[] = this.prepareGraphData(data)
+        this.graph = new DAGraph(this.getNodes(preprocessedData), this.getEdges(preprocessedData))
+    }
+
+    getNodes = (data: {id: string, node: Node, edges: {id: string, to: Node}[]}[]) => {
+        let nodes : Node[] = [];
+        data.forEach(node => {
+            nodes.push(node.node)
+        })
+
+        return nodes;
+    }
+
+    getEdges = (data: {id: string, node: Node, edges: {id: string, to: Node}[]}[]) => {
+        let edges : Edge[] = [];
+        data.forEach(fromNode => {
+            fromNode.edges.forEach(toNode => {
+                edges.push(new Edge(fromNode.node, toNode.to, fromNode.id))
+            })
+        })
+
+        return edges
+    }
+
+    prepareGraphData = (data: {action: string, inputIds: {id: string}[], outputIds: {id: string}[]}[]) => {
+        let nodes: string[] = [];
+        let graph: {id: string, node: Node, edges: {id: string, to: Node}[]}[] = [];
+
+        data.forEach(action => {
+            action.inputIds.forEach(elem => {
+                if (!nodes.includes(elem.id)) nodes.push(elem.id);
+            });
+            action.outputIds.forEach(elem => {
+                if (!nodes.includes(elem.id)) nodes.push(elem.id);
+            });
+        });
+
+        let py = 0;
+        nodes.forEach(node => {
+            graph.push({id: node, node: new Node(node, {y: py, x: 0}), edges: []})
+            py = py+50
+        })
+
+        nodes.forEach(node => {
+            data.forEach(action => {
+                action.inputIds.forEach(input => {
+                    if (input.id === node) {
+                        action.outputIds.forEach(target => {
+                            graph.forEach(elem => {
+                                if (elem.id === node) {
+                                    elem.edges.push({to: new Node(target.id), id: action.action})
+                                }
+                            })
+                        });
+                    }
+                })
+            })
+        })
+
+        console.log(graph)
+        return graph
+    }
+}

--- a/src/util/WorkflowsExplorer/Lineage.ts
+++ b/src/util/WorkflowsExplorer/Lineage.ts
@@ -25,10 +25,10 @@ export class Lineage {
         let edges : Edge[] = [];
         data.forEach(fromNode => {
             fromNode.edges.forEach(toNode => {
-                edges.push(new Edge(fromNode.node, toNode.to, toNode.id))
+                edges.push(new Edge(fromNode.node, toNode.to, toNode.id, 'runLineage'))
             })
         })
-
+        
         return edges
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,6 +2017,72 @@
     rc-resize-observer "^1.3.1"
     rc-util "^5.29.2"
 
+"@reactflow/background@11.2.3":
+  version "11.2.3"
+  resolved "https://registry.yarnpkg.com/@reactflow/background/-/background-11.2.3.tgz#d6479d5f7b7aac506781cc001f7b9196b6f6dadc"
+  integrity sha512-hFoxKt7ZkQclM7CXg7p3EHb+ngUslqFq122Gsrj55N5rFeEdtIkWHuoi+WS0dLRVfX+acuUs6hZl8JuC/JtQ7g==
+  dependencies:
+    "@reactflow/core" "11.7.3"
+    classcat "^5.0.3"
+    zustand "^4.3.1"
+
+"@reactflow/controls@11.1.14":
+  version "11.1.14"
+  resolved "https://registry.yarnpkg.com/@reactflow/controls/-/controls-11.1.14.tgz#15f991483f58ff4c13e805f3971d02ce78019ca6"
+  integrity sha512-UHqjuGGLLKL2sere0wOhaMRk5UxRj7S6dCzHQ5p1EOVw0pvl7eztWa+1DxYflqE215LP2LpI7Sloh0erouflUA==
+  dependencies:
+    "@reactflow/core" "11.7.3"
+    classcat "^5.0.3"
+    zustand "^4.3.1"
+
+"@reactflow/core@11.7.3", "@reactflow/core@^11.6.0":
+  version "11.7.3"
+  resolved "https://registry.yarnpkg.com/@reactflow/core/-/core-11.7.3.tgz#b6066199120d6574a190af76b8996d889ee80c26"
+  integrity sha512-sqrfB2qu5cF1FOPna/bq9MGHcdLy8b92jBzsAmDhEcdQHS+yg/gMWTnHVseqX4iBj+Ao7nQd9vwMqb5Bn93NUw==
+  dependencies:
+    "@types/d3" "^7.4.0"
+    "@types/d3-drag" "^3.0.1"
+    "@types/d3-selection" "^3.0.3"
+    "@types/d3-zoom" "^3.0.1"
+    classcat "^5.0.3"
+    d3-drag "^3.0.0"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
+    zustand "^4.3.1"
+
+"@reactflow/minimap@11.5.3":
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/@reactflow/minimap/-/minimap-11.5.3.tgz#a5cd18acfde1506557c4ff125a119daf8fceeed9"
+  integrity sha512-Wc/lYM6Ua0qLgeTkpEyLiND9Rl5aAzyE22O2DjZEGgEOviiyxGNCK93Kw5ba2xWIhWc2/1KYhotHw/IdjmXnYQ==
+  dependencies:
+    "@reactflow/core" "11.7.3"
+    "@types/d3-selection" "^3.0.3"
+    "@types/d3-zoom" "^3.0.1"
+    classcat "^5.0.3"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
+    zustand "^4.3.1"
+
+"@reactflow/node-resizer@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@reactflow/node-resizer/-/node-resizer-2.1.1.tgz#8f9b4e362e572dcddb54d43a67b5c5919b25937f"
+  integrity sha512-5Q+IBmZfpp/bYsw3+KRVJB1nUbj6W3XAp5ycx4uNWH+K98vbssymyQsW0vvKkIhxEPg6tkiMzO4UWRWvwBwt1g==
+  dependencies:
+    "@reactflow/core" "^11.6.0"
+    classcat "^5.0.4"
+    d3-drag "^3.0.0"
+    d3-selection "^3.0.0"
+    zustand "^4.3.1"
+
+"@reactflow/node-toolbar@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@reactflow/node-toolbar/-/node-toolbar-1.2.2.tgz#b927101d6ff251730e2ff0b912a448d16e03e8e1"
+  integrity sha512-YXD/+oPakAM+CiFL5STwo2gzIV5Eb5qi1Hiy0+/rrDyna8w5NFkJ8EEeXVWG3cAJw4FbeGv0DndmPyN4WaNl0A==
+  dependencies:
+    "@reactflow/core" "11.7.3"
+    classcat "^5.0.3"
+    zustand "^4.3.1"
+
 "@remix-run/router@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.5.0.tgz#57618e57942a5f0131374a9fdb0167e25a117fdc"
@@ -2315,7 +2381,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.2.tgz#b2fa80bab3bcead68680766e966f59cd6cb9a69f"
   integrity sha512-rxN6sHUXEZYCKV05MEh4z4WpPSqIw+aP7n9ZN6WYAAvZoEAghEK1WeVZMZcHRBwyaKflU43PCUAJNjFxCzPDjg==
 
-"@types/d3-drag@*":
+"@types/d3-drag@*", "@types/d3-drag@^3.0.1":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.2.tgz#5562da3e7b33d782c2c1f9e65c5e91bb01ee82cf"
   integrity sha512-qmODKEDvyKWVHcWWCOVcuVcOwikLVsyc4q4EBJMREsoQnR2Qoc2cZQUyFUPgO9q4S3qdSqJKBsuefv+h0Qy+tw==
@@ -2400,7 +2466,7 @@
   dependencies:
     "@types/d3-time" "*"
 
-"@types/d3-selection@*":
+"@types/d3-selection@*", "@types/d3-selection@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.5.tgz#27cd53b7672d405025e2414d98532d7934c16ebd"
   integrity sha512-xCB0z3Hi8eFIqyja3vW8iV01+OHGYR2di/+e+AiOcXIOrY82lcvWW8Ke1DYE/EUVMsBl4Db9RppSBS3X1U6J0w==
@@ -2438,6 +2504,14 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.2.tgz#067aa6a6ecbc75a78b753cc6f7a7f9f7e4e7d117"
   integrity sha512-t09DDJVBI6AkM7N8kuPsnq/3d/ehtRKBN1xSiYjjMCgbiw6HM6Ged5VhvswmhprfKyGvzeTEL/4WBaK9llWvlA==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@^3.0.1":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.3.tgz#5c29006a61ff7ca512fe21398c66ad95dd846674"
+  integrity sha512-OWk1yYIIWcZ07+igN6BeoG6rqhnJ/pYe+R1qWFM2DtW49zsoSjgb9G5xB0ZXA8hh2jAzey1XuRmMSoXdKw8MDA==
   dependencies:
     "@types/d3-interpolate" "*"
     "@types/d3-selection" "*"
@@ -4430,7 +4504,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classcat@^5.0.3:
+classcat@^5.0.3, classcat@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/classcat/-/classcat-5.0.4.tgz#e12d1dfe6df6427f260f03b80dc63571a5107ba6"
   integrity sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g==
@@ -12392,6 +12466,18 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+reactflow@^11.7.3:
+  version "11.7.3"
+  resolved "https://registry.yarnpkg.com/reactflow/-/reactflow-11.7.3.tgz#35ffd7ad5240639c0eaa64072af617c34f1d4cda"
+  integrity sha512-AgIr0lrzbZnd3GzcKkbJk9+n/eaVii39eMpM3hzvSni3i10sqe7Wg793B0ni3kgYhcCa9FgKkWimIt1j1Lh2qA==
+  dependencies:
+    "@reactflow/background" "11.2.3"
+    "@reactflow/controls" "11.1.14"
+    "@reactflow/core" "11.7.3"
+    "@reactflow/minimap" "11.5.3"
+    "@reactflow/node-resizer" "2.1.1"
+    "@reactflow/node-toolbar" "1.2.2"
+
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -14546,6 +14632,11 @@ use-query-params@1.1.6:
   dependencies:
     serialize-query-params "^1.2.1"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -15326,6 +15417,13 @@ zustand@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.7.2.tgz#7b44c4f4a5bfd7a8296a3957b13e1c346f42514d"
   integrity sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==
+
+zustand@^4.3.1:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.8.tgz#37113df8e9e1421b0be1b2dca02b49b76210e7c4"
+  integrity sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==
+  dependencies:
+    use-sync-external-store "1.2.0"
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
# What's new?
- The "Open lineage" button is now only available for runs whose statefiles have in/outputIds fields, and the corresponding lineage graph is constructed from these.
- It is now possible to open the action's details panel by clicking on the corresponding edge in the lineage panel
- When the action is in the current configuration (i.e. corresponds to an action's name available in the current configuration files of the project), there is the possibility of jumping directly to the current config view of the project

# What can be improved?
- From a UX point of view, adding highlight on hover of an edge (and highlighting the corresponding row in the timeline/panel) would be a plus. However this is made more difficult due to problems with dependencies and the react-flow package