### PR TITLE
Improve ConfigExplorer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,7 @@ export default function App() {
   
   const {data: manifest} = useManifest();
   const {data: configData, isLoading} = useConfig(manifest);
-  console.log('isLoading', isLoading);
-
+  
   const root = () => (
     <Routes>
       <Route element={<RootLayout isLoading={isLoading}/>}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import CssBaseline from '@mui/joy/CssBaseline';
-import { createHashRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
+import { createHashRouter, createRoutesFromElements, Route, RouterProvider, Routes } from 'react-router-dom';
 import ConfigExplorer from './components/ConfigExplorer/ConfigExplorer';
 import DataDisplayView from './components/ConfigExplorer/DataDisplayView';
 import GlobalConfigView from './components/ConfigExplorer/GlobalConfigView';
@@ -22,48 +22,36 @@ export default function App() {
   const {data: manifest} = useManifest();
   const {data: configData, isLoading} = useConfig(manifest);
   
-  /**
-   * `router` sets up the router for the application using `createHashRouter` and `createRoutesFromElements`.
-   * It returns a router object.
-   * @returns The router object.
-   */
-  const router = () => createHashRouter(
-    createRoutesFromElements(
-      <Route path='/' element={<RootLayout isLoading={isLoading}/>}>
-        <Route path='/' element={<Home/>}/>
-        <Route path='/workflows/' element={<Workflows/>}/>
-        <Route path='/workflows/:workflow' element={<WorkflowHistory/>}/>
-        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab' element={<Run configData={configData}/>}/>
-        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run configData={configData} panelOpen={true}/>}/>
-        <Route path='*' element={<NotFound/>}/>
-        <Route path='/config' element={<ConfigExplorer data={configData}/>}>
-          <Route
-              path='/config/search/:ownSearchString' //the ownSearchString is our definition of a 
-              //search because of problems with routing Search Parameters
-              element={
-                <SearchResults data={configData}/>
-              } />
-          <Route
-            path="/config/:elementType/:elementName"
-            element={
-              <DataDisplayView data={configData} />
-            } />
-          <Route
-            path="/config/globalOptions"
-            element={
-              <GlobalConfigView data={configData?.global}/>
-            } />
-        </Route> 
+  const root = () => (
+    <Routes>
+      <Route path='/*' element={<RootLayout isLoading={isLoading}/>}>
+        <Route index element={<Home/>}/>
+        <Route path='workflows/' element={<Workflows/>}/>
+        <Route path='workflows/:flowId' element={<WorkflowHistory/>}/>
+        <Route path='workflows/:flowId/:runNumber/:taskId/:tab' element={<Run configData={configData}/>}/>
+        <Route path='workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run configData={configData} panelOpen={true}/>}/>
+        <Route path='workflows/*' element={<NotFound/>}/>
+        <Route path='config/*' element={<ConfigExplorer data={configData}/>}>
+          <Route path='search/:ownSearchString' //the ownSearchString is our definition of a 
+          //search because of problems with routing Search Parameters
+          element={<SearchResults data={configData}/>} />
+          <Route path=":elementType/:elementName" 
+          element={<DataDisplayView data={configData} />} />
+          <Route path="globalOptions" 
+          element={<GlobalConfigView data={configData?.global}/>} />
+        </Route>
       </Route>
-    )
+    </Routes>
   )
+
+  const router = () => createHashRouter([
+    { path: "*", Component: root },    
+  ])
 
   return (
     <>
       <CssBaseline />
-      
-        {/* Provide the router object to the rest of the application with `RouterProvider` */}
-        <RouterProvider router={router()}/>
+      <RouterProvider router={router()}/>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,25 +21,21 @@ export default function App() {
   
   const {data: manifest} = useManifest();
   const {data: configData, isLoading} = useConfig(manifest);
-  
+  console.log('isLoading', isLoading);
+
   const root = () => (
     <Routes>
-      <Route path='/*' element={<RootLayout isLoading={isLoading}/>}>
+      <Route element={<RootLayout isLoading={isLoading}/>}>
         <Route index element={<Home/>}/>
-        <Route path='workflows/' element={<Workflows/>}/>
-        <Route path='workflows/:flowId' element={<WorkflowHistory/>}/>
-        <Route path='workflows/:flowId/:runNumber/:taskId/:tab' element={<Run configData={configData}/>}/>
-        <Route path='workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run configData={configData} panelOpen={true}/>}/>
-        <Route path='workflows/*' element={<NotFound/>}/>
-        <Route path='config/*' element={<ConfigExplorer data={configData}/>}>
-          <Route path='search/:ownSearchString' //the ownSearchString is our definition of a 
-          //search because of problems with routing Search Parameters
-          element={<SearchResults data={configData}/>} />
-          <Route path=":elementType/:elementName" 
-          element={<DataDisplayView data={configData} />} />
-          <Route path="globalOptions" 
-          element={<GlobalConfigView data={configData?.global}/>} />
-        </Route>
+        {configData && <>
+          <Route path='workflows/' element={<Workflows/>}/>
+          <Route path='workflows/:flowId' element={<WorkflowHistory/>}/>
+          <Route path='workflows/:flowId/:runNumber/:taskId/:tab' element={<Run configData={configData}/>}/>
+          <Route path='workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run configData={configData} panelOpen={true}/>}/>
+          <Route path='workflows/*' element={<NotFound/>}/>
+          <Route path='config/*' element={<ConfigExplorer data={configData}/>}/>
+          </>
+        }
       </Route>
     </Routes>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import CssBaseline from '@mui/joy/CssBaseline';
 import { createHashRouter, createRoutesFromElements, Route, RouterProvider, Routes } from 'react-router-dom';
 import ConfigExplorer from './components/ConfigExplorer/ConfigExplorer';
-import DataDisplayView from './components/ConfigExplorer/DataDisplayView';
+import ElementDetails from './components/ConfigExplorer/ElementDetails';
 import GlobalConfigView from './components/ConfigExplorer/GlobalConfigView';
 import SearchResults from './components/ConfigExplorer/SearchResults';
 import Home from './components/HomeMenu/Home';
@@ -26,15 +26,12 @@ export default function App() {
     <Routes>
       <Route element={<RootLayout isLoading={isLoading}/>}>
         <Route index element={<Home/>}/>
-        {configData && <>
-          <Route path='workflows/' element={<Workflows/>}/>
-          <Route path='workflows/:flowId' element={<WorkflowHistory/>}/>
-          <Route path='workflows/:flowId/:runNumber/:taskId/:tab' element={<Run configData={configData}/>}/>
-          <Route path='workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run configData={configData} panelOpen={true}/>}/>
-          <Route path='workflows/*' element={<NotFound/>}/>
-          <Route path='config/*' element={<ConfigExplorer data={configData}/>}/>
-          </>
-        }
+        <Route path='workflows/' element={<Workflows/>}/>
+        <Route path='workflows/:flowId' element={<WorkflowHistory/>}/>
+        <Route path='workflows/:flowId/:runNumber/:taskId/:tab' element={<Run/>}/>
+        <Route path='workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run panelOpen={true}/>}/>
+        <Route path='workflows/*' element={<NotFound/>}/>
+        <Route path='config/*' element={<ConfigExplorer configData={configData}/>}/>
       </Route>
     </Routes>
   )

--- a/src/components/ConfigExplorer/ComponentsStyles.css
+++ b/src/components/ConfigExplorer/ComponentsStyles.css
@@ -5,7 +5,6 @@
 
 .data-flow{
     /*background-color: lightblue;*/
-    height: 800px;
     font-family: Arial, Helvetica, sans-serif;
     font-weight: bold;
 }
@@ -36,10 +35,14 @@ a:link{
 }
 input[type=checkbox] {width:20px; height:20px;}
 
-/*Media styles*/
+.markdown-body table {
+    width: auto !important;
+}
+
+/*Media styles
 @media  screen and (max-width: 1400px) {
     .data-flow{
         height: 440px;
     }
 }
-
+*/

--- a/src/components/ConfigExplorer/ConfigExplorer.tsx
+++ b/src/components/ConfigExplorer/ConfigExplorer.tsx
@@ -1,15 +1,18 @@
 import { Sheet } from '@mui/joy';
 import { useRef, useState } from 'react';
-import { Outlet } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import PageHeader from '../../layouts/PageHeader';
 import './App.css';
 import ElementList from './ElementList';
 import DraggableDivider from '../../layouts/DraggableDivider';
+import SearchResults from './SearchResults';
+import DataDisplayView from './DataDisplayView';
+import GlobalConfigView from './GlobalConfigView';
 
 
 function ConfigExplorer(props: { data: any }) {
 	const { data } = props;
-	const [listWidth, setListWidth] = useState(150); // initial width of left element
+	const [listWidth, setListWidth] = useState(250); // initial width of left element
 	const listRef = useRef<HTMLDivElement>(null);
 
 	return (
@@ -18,7 +21,11 @@ function ConfigExplorer(props: { data: any }) {
 			<Sheet sx={{ display: 'flex', height: "calc(100% - 6.6rem)"}}>
 				<ElementList data={data} width={listWidth} mainRef={listRef} />
 				<DraggableDivider setWidth={setListWidth} cmpRef={listRef} isRightCmp={false} />
-				<Outlet />
+				<Routes>
+					<Route path='search/:ownSearchString' element={<SearchResults data={data}/>} /> //the ownSearchString is our definition of a search because of problems with routing Search Parameters
+					<Route path=":elementType/:elementName" element={<DataDisplayView data={data} />} />
+					<Route path="globalOptions" element={<GlobalConfigView data={data?.global}/>} />
+		  		</Routes>
 			</Sheet>
 		</Sheet>
 	);

--- a/src/components/ConfigExplorer/ConfigExplorer.tsx
+++ b/src/components/ConfigExplorer/ConfigExplorer.tsx
@@ -1,5 +1,5 @@
 import { Sheet } from '@mui/joy';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Route, Routes } from "react-router-dom";
 import PageHeader from '../../layouts/PageHeader';
 import './App.css';
@@ -14,12 +14,47 @@ function ConfigExplorer(props: { data: any }) {
 	const { data } = props;
 	const [listWidth, setListWidth] = useState(250); // initial width of left element
 	const listRef = useRef<HTMLDivElement>(null);
+	const [filter, setFilter] = useState<string>();
+	const [allDataObjects, setAllDataObjects] = useState<string[]>([]);
+	const [allActions, setAllActions] = useState<string[]>([]);
+	const [allConnections, setAllConnections] = useState<string[]>([]);	
+	const [currentDataObjects, setCurrentDataObjects] = useState(allDataObjects);
+	const [currentActions, setCurrentActions] = useState<string[]>(allActions);
+	const [currentConnections, setCurrentConnections] = useState<string[]>(allConnections);
+
+	useEffect(() => {
+		if (data) {
+			if (data.dataObjects) {
+				setAllDataObjects(Object.keys(data.dataObjects).sort());
+			}
+			if (data.actions) {
+				setAllActions(Object.keys(data.actions).sort());
+			}
+			if (data.connections) {
+				setAllConnections(Object.keys(data.connections).sort());
+			}
+		}
+	}, [data]);
+
+	useEffect(() => {
+		if (filter && filter.length>0) {
+			const searchText = filter.toLowerCase()
+			setCurrentDataObjects(allDataObjects.filter(a => a.toLowerCase().includes(searchText)));
+			setCurrentActions(allActions.filter(a => a.toLowerCase().includes(searchText)));
+			setCurrentConnections(allConnections.filter(a => a.toLowerCase().includes(searchText)));
+		} else {
+			setCurrentDataObjects(allDataObjects);
+			setCurrentActions(allActions);
+			setCurrentConnections(allConnections);
+		}
+	}, [filter, allDataObjects, allActions, allConnections]);
+
 
 	return (
 		<Sheet sx={{ display: 'flex', height: "100%", flexDirection: 'column' }}>
 			<PageHeader title={'Configuration'} noBack={true} />
 			<Sheet sx={{ display: 'flex', height: "calc(100% - 6.6rem)"}}>
-				<ElementList data={data} width={listWidth} mainRef={listRef} />
+				<ElementList dataObjects={currentDataObjects} actions={currentActions} connections={currentConnections} width={listWidth} mainRef={listRef} filter={filter} setFilter={setFilter} />
 				<DraggableDivider setWidth={setListWidth} cmpRef={listRef} isRightCmp={false} />
 				<Routes>
 					<Route path='search/:ownSearchString' element={<SearchResults data={data}/>} /> //the ownSearchString is our definition of a search because of problems with routing Search Parameters

--- a/src/components/ConfigExplorer/ConfigExplorer.tsx
+++ b/src/components/ConfigExplorer/ConfigExplorer.tsx
@@ -1,28 +1,27 @@
+import { Sheet } from '@mui/joy';
+import { useRef, useState } from 'react';
+import { Outlet } from "react-router-dom";
+import PageHeader from '../../layouts/PageHeader';
 import './App.css';
 import ElementList from './ElementList';
-import { Outlet } from "react-router-dom";
-import { Sheet } from '@mui/joy';
-import PageHeader from '../../layouts/PageHeader';
+import DraggableDivider from '../../layouts/DraggableDivider';
 
 
+function ConfigExplorer(props: { data: any }) {
+	const { data } = props;
+	const [listWidth, setListWidth] = useState(150); // initial width of left element
+	const listRef = useRef<HTMLDivElement>(null);
 
-function ConfigExplorer(props: {data: any}) {
-  const { data } = props;
-
-  return (
-    <>
-    	<PageHeader title={'Configuration'} noBack={true} />
-    	<Sheet
-			sx={{
-				display: 'flex',
-				height: '100%',
-			}}
-			>
-    	  	<ElementList data={data} />
-    	  	<Outlet />
-    	</Sheet>
-    </>
-  );
+	return (
+		<Sheet sx={{ display: 'flex', height: "100%", flexDirection: 'column' }}>
+			<PageHeader title={'Configuration'} noBack={true} />
+			<Sheet sx={{ display: 'flex', height: "calc(100% - 6.6rem)"}}>
+				<ElementList data={data} width={listWidth} mainRef={listRef} />
+				<DraggableDivider setWidth={setListWidth} cmpRef={listRef} isRightCmp={false} />
+				<Outlet />
+			</Sheet>
+		</Sheet>
+	);
 }
 
 export default ConfigExplorer;

--- a/src/components/ConfigExplorer/DataDisplayView.tsx
+++ b/src/components/ConfigExplorer/DataDisplayView.tsx
@@ -11,6 +11,7 @@ import { ReactFlowProvider } from "react-flow-renderer";
 import { Button, Sheet } from "@mui/joy";
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
 import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
+import DraggableDivider from "../../layouts/DraggableDivider";
 
 export interface displayProps {
   data: any; // complete configuration
@@ -24,6 +25,8 @@ export default function DataDisplayView(props: displayProps) {
   const [connectionConfigObj, setConnectionConfigObj] = React.useState();
   const [selectedTyp, setSelectedTab] = React.useState('description');
   const [openLineage, setOpenLineage] = React.useState(false);
+  const [lineageWidth, setLineageWidth] = React.useState(500);
+  const lineageRef = React.useRef<HTMLDivElement>(null);  
 
   React.useEffect(() => {
     if (elementType && elementName) {
@@ -39,8 +42,8 @@ export default function DataDisplayView(props: displayProps) {
   };
 
   return (
-	<Sheet sx={{display: 'flex', height: '100%', flex: 1,}}>
-		<Sheet sx={{display: 'flex', flexDirection: 'column', flex: 2, overflowY: 'scroll', scrollbarWidth: 'none',  p: '1rem'}}>
+	<>
+		<Sheet sx={{ flex: 1, minWidth: '500px', display: 'flex', flexDirection: 'column',  p: '1rem'}}>
 
 			<TabContext value={selectedTyp}>
 				<Sheet sx={{ display: 'flex', justifyContent: 'space-between'}}>
@@ -49,7 +52,7 @@ export default function DataDisplayView(props: displayProps) {
 						<Tab label="Configuration" value="configuration" />
 					{/*  {(elementType==="actions" || elementType==="dataObjects") && <Tab label="Lineage" value="lineage" sx={{height: "15px"}} />} */}
 					</Tabs>
-					<Sheet sx={{display: 'flex', alignItems: 'center'}}>
+					<Sheet>
 						{!openLineage ?
 							(
 								<Button size="sm" onClick={() => setOpenLineage(!openLineage)}>
@@ -64,32 +67,25 @@ export default function DataDisplayView(props: displayProps) {
 						)}
 					</Sheet>
 				</Sheet>
-				<TabPanel value="description" className="content-panel">
-					<Sheet sx={{maxWidth: '90rem', flex: 1}}>
-						<DescriptionTab elementName={elementName as string} data={configObj} elementType={elementType as string}/>
-					</Sheet>
+				<TabPanel value="description" className="content-panel" sx={{height: '100%', width: '100%', overflowY: 'auto'}}>
+					<DescriptionTab elementName={elementName as string} data={configObj} elementType={elementType as string}/>
 				</TabPanel>
-				<TabPanel value="configuration" className="content-panel">
-					<Sheet sx={{width: 'auto', flex: 1}}>
+				<TabPanel value="configuration" className="content-panel"  sx={{height: '100%', width: '100%', overflowY: 'auto'}}>
 					<ConfigurationTab data={configObj} elementName={elementName as string} elementType={elementType as string} connection={connectionConfigObj} />
-					</Sheet>
 				</TabPanel>
 			</TabContext> 
 		</Sheet>
-		<Sheet sx={{borderRight: openLineage ? '1px solid lightgrey' : undefined}}>
-			
-		</Sheet>
+
 		{openLineage &&
-		<Sheet
-		sx={{
-			flex: 3,
-			height: '100%',
-		}}
-		>
-			<ReactFlowProvider>
-				<LineageTab data={props.data} elementName={elementName as string} elementType={elementType as string} />
-			</ReactFlowProvider>
-		</Sheet>}
-	</Sheet>
+			<>
+				<DraggableDivider setWidth={setLineageWidth} cmpRef={lineageRef} isRightCmp={true} />
+				<Sheet sx={{width: lineageWidth, height: '100%'}} ref={lineageRef}>
+					<ReactFlowProvider>
+						<LineageTab data={props.data} elementName={elementName as string} elementType={elementType as string} />
+					</ReactFlowProvider>
+				</Sheet>
+			</>
+		}		
+	</>
   );
 } 

--- a/src/components/ConfigExplorer/DataTable.tsx
+++ b/src/components/ConfigExplorer/DataTable.tsx
@@ -1,0 +1,56 @@
+import { Box, Table } from "@mui/joy";
+import { TablePagination } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+
+export default function DataTable(props: {data: any[], columns: string[], navigatePrefix: string, navigateAttr: string}) {
+
+    const {data, columns, navigatePrefix, navigateAttr} = props;
+    const [pageData, setPageData] = useState<any[]>([]);
+    const [pageNb, setPageNb] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(25);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        setPageData(data.slice(pageNb*rowsPerPage, pageNb*rowsPerPage + rowsPerPage));
+    }, [data, pageNb, rowsPerPage])
+
+    function handleChangeRowsPerPage(event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+        const newRowsPerPage = parseInt(event.target.value, 25)
+        const newPageNb = pageNb * rowsPerPage / newRowsPerPage;
+        setRowsPerPage(newRowsPerPage);
+        setPageNb(newPageNb);
+    }
+
+    function handleChangePage(event: React.MouseEvent<HTMLButtonElement> | null, newPageNb: number) {
+        setPageNb(newPageNb);
+    }
+
+    function prepValue(v: any) {
+        if (typeof v === 'object') return JSON.stringify(v);
+        return v
+    }
+    
+    return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <Box sx={{ maxHeight: '64vh', overflow: 'auto' }}>
+            <Table size='sm' hoverRow color='neutral' stickyHeader>
+                <thead>
+                    <tr>
+                        {columns.map(c => <th>{c}</th>)}
+                    </tr>
+                </thead>
+                <tbody>
+                    {pageData.map(row => (
+                        <tr style={{cursor: 'pointer'}} onClick={() => navigate(navigatePrefix+row[navigateAttr])}>
+                            {columns.map(c => <td>{prepValue(row[c])}</td>)}
+                        </tr>
+                    ))}
+                </tbody>
+            </Table>
+        </Box>
+        <TablePagination component="div" count={data.length} page={pageNb} onPageChange={handleChangePage} rowsPerPage={rowsPerPage} onRowsPerPageChange={handleChangeRowsPerPage}/>
+    </Box>
+    )
+  }

--- a/src/components/ConfigExplorer/ElementDetails.tsx
+++ b/src/components/ConfigExplorer/ElementDetails.tsx
@@ -12,14 +12,12 @@ import { Button, Sheet } from "@mui/joy";
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
 import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
 import DraggableDivider from "../../layouts/DraggableDivider";
-
-export interface displayProps {
-  data: any; // complete configuration
-}
+import { ConfigData } from "../../util/ConfigExplorer/ConfigData";
 
 
-export default function DataDisplayView(props: displayProps) {
+export default function ElementDetails(props: {configData?: ConfigData}) {
 
+  const {configData} = props;
   const {elementName, elementType} = useParams();
   const [configObj, setConfigObj] = React.useState();
   const [connectionConfigObj, setConnectionConfigObj] = React.useState();
@@ -29,12 +27,12 @@ export default function DataDisplayView(props: displayProps) {
   const lineageRef = React.useRef<HTMLDivElement>(null);  
 
   React.useEffect(() => {
-    if (elementType && elementName) {
-      let obj = props.data[elementType][elementName];
-      if (obj && obj['connectionId']) setConnectionConfigObj(props.data['connections'][obj['connectionId']]);
+    if (configData && elementType && elementName) {
+      let obj = configData[elementType][elementName];
+      if (obj && obj['connectionId']) setConnectionConfigObj(configData['connections'][obj['connectionId']]);
       setConfigObj(obj);
     }
-  }, [elementName, elementType, props.data]);
+  }, [elementName, elementType, configData]);
 
   // change selected tab
   const handleChange = (_: React.SyntheticEvent, newValue: string) => {
@@ -81,7 +79,7 @@ export default function DataDisplayView(props: displayProps) {
 				<DraggableDivider setWidth={setLineageWidth} cmpRef={lineageRef} isRightCmp={true} />
 				<Sheet sx={{width: lineageWidth, height: '100%'}} ref={lineageRef}>
 					<ReactFlowProvider>
-						<LineageTab data={props.data} elementName={elementName as string} elementType={elementType as string} />
+						<LineageTab configData={configData} elementName={elementName as string} elementType={elementType as string} />
 					</ReactFlowProvider>
 				</Sheet>
 			</>

--- a/src/components/ConfigExplorer/ElementList.tsx
+++ b/src/components/ConfigExplorer/ElementList.tsx
@@ -21,6 +21,8 @@ import { Box } from '@mui/material';
 
 interface ElementListProps{
   data: any;
+  width: number;
+  mainRef: React.Ref<HTMLDivElement>;
 }
 
 //props.data should be the JsonObject (already parsed from HOCON)
@@ -76,7 +78,7 @@ export default function ElementList(props: ElementListProps) {
 
   const dataObjectsCompleteList = currentDataObjects.map((dataObject,i) => (
     <Link to={`/config/dataObjects/${dataObject}`} key={"d"+i}>
-      <ListItemButton sx={{ pl: '1rem' }}>
+      <ListItemButton sx={{ pl: '1rem', paddingRight: '0px' }}>
         <ListItemIcon>
           <TableViewTwoTone />
         </ListItemIcon>
@@ -92,7 +94,7 @@ export default function ElementList(props: ElementListProps) {
 
   const actionsCompleteList = currentActions.map((action,i) => (
     <Link to={`/config/actions/${action}`} key={"a"+i}>
-      <ListItemButton sx={{ pl: '1rem' }}>
+      <ListItemButton sx={{ pl: '1rem', paddingRight: '0px' }}>
         <ListItemIcon>
           <RocketLaunchOutlined />
         </ListItemIcon>
@@ -108,7 +110,7 @@ export default function ElementList(props: ElementListProps) {
 
   const connectionsCompleteList = currentConnections.map((connection,i) => (
     <Link to={`/config/connections/${connection}`} key={"c"+i}>
-      <ListItemButton sx={{ pl: '1rem' }}>
+      <ListItemButton sx={{ pl: '1rem', paddingRight: '0px' }}>
         <ListItemIcon>
           <LanOutlinedIcon />
         </ListItemIcon>
@@ -122,9 +124,8 @@ export default function ElementList(props: ElementListProps) {
     </Link>
   ));
 
-
   return (
-    <Box sx={{width: '17rem', height: '100%', pt:'1rem', borderRight: '1px solid lightgray'}}>
+    <Box sx={{width: props.width, minWidth: '100px', maxWidth: '500px', height: '100%', pt:'1rem'}} ref={props.mainRef}>
       <TextField
         className="search_field"
         variant="outlined"
@@ -132,7 +133,7 @@ export default function ElementList(props: ElementListProps) {
         label="Search element"
         value={currentSearch}
         onChange={(e) => handleTextField(e.target.value)} //e is the event Object triggered by the onChange
-        sx={{width: "100%", "paddingRight": "25px"}}
+        sx={{width: "100%", "paddingRight": "10px"}}
       />
 
       <List
@@ -145,7 +146,7 @@ export default function ElementList(props: ElementListProps) {
           </ListSubheader>
         }*/
       >
-        <ListItemButton onClick={handleClickDataObjectsList}>
+        <ListItemButton onClick={handleClickDataObjectsList} sx={{ paddingRight: '0px' }}>
           <ListItemIcon>
             <TableView />
           </ListItemIcon>
@@ -157,7 +158,7 @@ export default function ElementList(props: ElementListProps) {
             {dataObjectsCompleteList}
           </List>
         </Collapse>
-        <ListItemButton onClick={handleClickActionsList}>
+        <ListItemButton onClick={handleClickActionsList} sx={{ paddingRight: '0px' }}>
           <ListItemIcon>
             <RocketLaunch />
           </ListItemIcon>
@@ -169,7 +170,7 @@ export default function ElementList(props: ElementListProps) {
             {actionsCompleteList}
           </List>
         </Collapse>
-        <ListItemButton onClick={handleClickConnectionsList}>
+        <ListItemButton onClick={handleClickConnectionsList} sx={{ paddingRight: '0px' }}>
           <ListItemIcon>
             <LanIcon />
           </ListItemIcon>

--- a/src/components/ConfigExplorer/ElementList.tsx
+++ b/src/components/ConfigExplorer/ElementList.tsx
@@ -20,27 +20,21 @@ import { Box } from '@mui/material';
 
 
 interface ElementListProps{
-  data: any;
+  dataObjects: string[];
+  actions: string[];
+  connections: string[];
   width: number;
   mainRef: React.Ref<HTMLDivElement>;
+  filter?: string;
+  setFilter: (string) => void;
 }
 
 //props.data should be the JsonObject (already parsed from HOCON)
 export default function ElementList(props: ElementListProps) {
 
-  const allDataObjects = Object.keys(props.data.dataObjects).sort();
-  const allActions = Object.keys(props.data.actions).sort();
-  let allConnections : string[] = [];
-  if (Object.keys(props.data).includes('connections')){
-    allConnections = Object.keys(props.data.connections);
-  }
   const [openDataObjectsList, setOpenDataObjectsList] = React.useState(false);
   const [openActionsList, setOpenActionsList] = React.useState(false);
   const [openConnectionsList, setOpenConnectionsList] = React.useState(false);
-  const [currentDataObjects, setCurrentDataObjects] = React.useState(allDataObjects);
-  const [currentActions, setCurrentActions] = React.useState(allActions);
-  const [currentConnections, setCurrentConnections] = React.useState(allConnections);
-  const [currentSearch, setCurrentSearch] = React.useState('');
   const urlParams = useMatch('/:elementType/:elementName');
 
   const handleClickDataObjectsList = () => {
@@ -61,14 +55,7 @@ export default function ElementList(props: ElementListProps) {
       setOpenDataObjectsList(true);
       setOpenConnectionsList(true);
     }
-    setCurrentSearch(text);
-    const searchText = text.toLowerCase()
-    const cdo = allDataObjects.filter(a => a.toLowerCase().includes(searchText));
-    const ca = allActions.filter(a => a.toLowerCase().includes(searchText));
-    const cc = allConnections.filter(a => a.toLowerCase().includes(searchText));
-    setCurrentDataObjects(cdo);
-    setCurrentActions(ca);
-    setCurrentConnections(cc);
+    props.setFilter(text);
   }
 
   function returnBoldString(elementType:string, elementName: string){
@@ -76,7 +63,7 @@ export default function ElementList(props: ElementListProps) {
     else return 'normal';
   }
 
-  const dataObjectsCompleteList = currentDataObjects.map((dataObject,i) => (
+  const dataObjectsCompleteList = props.dataObjects.map((dataObject,i) => (
     <Link to={`/config/dataObjects/${dataObject}`} key={"d"+i}>
       <ListItemButton sx={{ pl: '1rem', paddingRight: '0px' }}>
         <ListItemIcon>
@@ -92,7 +79,7 @@ export default function ElementList(props: ElementListProps) {
     </Link>
   ));
 
-  const actionsCompleteList = currentActions.map((action,i) => (
+  const actionsCompleteList = props.actions.map((action,i) => (
     <Link to={`/config/actions/${action}`} key={"a"+i}>
       <ListItemButton sx={{ pl: '1rem', paddingRight: '0px' }}>
         <ListItemIcon>
@@ -108,7 +95,7 @@ export default function ElementList(props: ElementListProps) {
     </Link>
   ));
 
-  const connectionsCompleteList = currentConnections.map((connection,i) => (
+  const connectionsCompleteList = props.connections.map((connection,i) => (
     <Link to={`/config/connections/${connection}`} key={"c"+i}>
       <ListItemButton sx={{ pl: '1rem', paddingRight: '0px' }}>
         <ListItemIcon>
@@ -131,7 +118,7 @@ export default function ElementList(props: ElementListProps) {
         variant="outlined"
         size="small"
         label="Search element"
-        value={currentSearch}
+        value={props.filter}
         onChange={(e) => handleTextField(e.target.value)} //e is the event Object triggered by the onChange
         sx={{width: "100%", "paddingRight": "10px"}}
       />

--- a/src/components/ConfigExplorer/ElementTable.tsx
+++ b/src/components/ConfigExplorer/ElementTable.tsx
@@ -1,0 +1,41 @@
+import { Sheet } from "@mui/joy";
+import { TabContext, TabPanel } from "@mui/lab";
+import { Tab, Tabs } from "@mui/material";
+import { useNavigate, useParams } from "react-router-dom";
+import { ConfigDataLists } from "../../util/ConfigExplorer/ConfigData";
+import DataTable from "./DataTable";
+
+export default function ElementTable(props: {dataLists: ConfigDataLists}) {
+    
+    const {dataLists} = props;
+    const {elementType} = useParams();
+    const navigate = useNavigate();    
+
+    const handleChange = (_: React.SyntheticEvent, newValue: string) => {
+        navigate(`/config/${newValue}`);
+    };    
+
+    return (
+		<Sheet sx={{ flex: 1, minWidth: '500px', display: 'flex', flexDirection: 'column',  p: '1rem'}}>
+
+			<TabContext value={elementType || "dataObjects"}>
+				<Sheet sx={{ display: 'flex', justifyContent: 'space-between'}}>
+					<Tabs value={elementType} onChange={handleChange} aria-label="element tabs">
+						<Tab label="Data Objects" value="dataObjects" />
+						<Tab label="Actions" value="actions" />
+						<Tab label="Connections" value="connections" />
+					</Tabs>
+				</Sheet>
+				<TabPanel value="dataObjects" className="content-panel" sx={{height: '100%', width: '100%', overflowY: 'auto'}}>
+                    <DataTable data={dataLists.dataObjects} columns={["id", "type", "path", "table", "connectionId"]} navigatePrefix={`/config/dataObjects/`} navigateAttr="id"/>
+				</TabPanel>
+				<TabPanel value="actions" className="content-panel"  sx={{height: '100%', width: '100%', overflowY: 'auto'}}>
+                    <DataTable data={dataLists.actions} columns={["id", "type", "inputIds", "outputIds"]} navigatePrefix={`/config/actions/`} navigateAttr="id"/>
+				</TabPanel>
+				<TabPanel value="connections" className="content-panel"  sx={{height: '100%', width: '100%', overflowY: 'auto'}}>
+                    <DataTable data={dataLists.connections} columns={["id", "type"]} navigatePrefix={`/config/connections/`} navigateAttr="id"/>
+				</TabPanel>
+            </TabContext> 
+		</Sheet>        
+    )
+  }

--- a/src/components/ConfigExplorer/GlobalConfigView.tsx
+++ b/src/components/ConfigExplorer/GlobalConfigView.tsx
@@ -3,6 +3,7 @@ import { Box, Tab, Tabs } from "@mui/material";
 import TabPanel from '@mui/lab/TabPanel';
 import TabContext from '@mui/lab/TabContext';
 import { createPropertiesComponent } from './PropertiesComponent';
+import { Sheet } from "@mui/joy";
 
 interface ViewProps {
   data: any; // global configuration
@@ -12,16 +13,18 @@ export default function GlobalConfigView(props: ViewProps) {
 
   if (props.data){
     return(
-      <TabContext value={'configuration'}>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs value={'configuration'} aria-label="element tabs">
-          <Tab label="Configuration" value="configuration" sx={{height: "15px"}} />
-        </Tabs>
-      </Box>
-      <TabPanel value="configuration">
-        {createPropertiesComponent({obj: props.data})}
-      </TabPanel>
-    </TabContext>      
+      <Sheet sx={{ display: 'flex', flexDirection: 'column',  p: '1rem'}}>
+        <TabContext value={'configuration'}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tabs value={'configuration'} aria-label="element tabs">
+              <Tab label="Configuration" value="configuration" sx={{height: "15px"}} />
+            </Tabs>
+          </Box>
+          <TabPanel value="configuration" className="content-panel">
+            {createPropertiesComponent({obj: props.data})}
+          </TabPanel>
+        </TabContext>      
+      </Sheet>
     );
   }
   else{

--- a/src/components/ConfigExplorer/LineageTab.tsx
+++ b/src/components/ConfigExplorer/LineageTab.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import OpenWithIcon from '@mui/icons-material/OpenWith';
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
 import DownloadButton from './DownloadLineageButton';
+import { ConfigData } from '../../util/ConfigExplorer/ConfigData';
 
 
 
@@ -91,11 +92,11 @@ function createReactFlowEdges(dataObjectsAndActions: DAGraph){
 
 
 interface flowProps {
-  elementName: string,
-  elementType: string,
-  data?: object,
-  graph?: PartialDataObjectsAndActions, 
-  runContext?: boolean,
+  elementName: string;
+  elementType: string;
+  configData?: ConfigData;
+  graph?: PartialDataObjectsAndActions;
+  runContext?: boolean;
 }
 
 type flowNodeWithString = Node<any> & {jsonString?:string} //merge Node type of ReactFlow with an (optional) String attribute. 
@@ -110,7 +111,7 @@ type flowEdgeWithString = Edge<any> & {jsonString?:string} & {old_id?: string}
 function LineageTab(props: flowProps) {
   const url = useParams();
 
-  const doa = props.graph ? props.graph : new DataObjectsAndActions(props.data);
+  const doa = props.graph ? props.graph : new DataObjectsAndActions(props.configData);
   let nodes_init: any[] = [];
   let edges_init: any[] = [];
   const [onlyDirectNeighbours, setOnlyDirectNeighbours] = useState([true, 'Expand Graph']);
@@ -215,12 +216,12 @@ function LineageTab(props: flowProps) {
   const navigate = useNavigate();   
   function clickOnNode(node: flowNodeWithString){
     //renderPartialGraph(node.id); //DEPRECATED WAY OF SHOWING PARTIAL GRAPHS
-    if (props.data) {
+    if (props.configData) {
       navigate(`/config/dataObjects/${node.id}`); //Link programmatically
     }
   } 
   function clickOnEdge(edge: flowEdgeWithString){
-    if (props.data) { 
+    if (props.configData) { 
       navigate(`/config/actions/${edge.old_id}`); //Link programmatically
     } else {
       navigate(`/workflows/${url.flowId}/${url.runNumber}/${url.taskId}/${url.tab}/${edge.old_id}`);
@@ -282,7 +283,7 @@ function LineageTab(props: flowProps) {
           </IconButton>
         </div>
 
-        {props.data && <div title={onlyDirectNeighbours[1] as string} style={{  zIndex: 4, cursor: 'pointer' }}>
+        {props.configData && <div title={onlyDirectNeighbours[1] as string} style={{  zIndex: 4, cursor: 'pointer' }}>
           <IconButton 
             color='inherit'
             onClick={expandGraph}>

--- a/src/components/WorkflowsExplorer/Run/ContentDrawer.tsx
+++ b/src/components/WorkflowsExplorer/Run/ContentDrawer.tsx
@@ -3,6 +3,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import { useNavigate, useParams } from "react-router-dom";
 import Attempt from "../../../util/WorkflowsExplorer/Attempt";
 import { Row } from "../../../types"
+import { useManifest } from "../../../hooks/useManifest";
+import { useConfig } from "../../../hooks/useConfig";
 
 const getRow = (attempt: Attempt, taskName: string) => {
     if (taskName === 'err') throw(new Error('was not able to fetch task name'));
@@ -161,18 +163,15 @@ const ContentSheet = (props: {action: Row}) => {
  * @param props attempt: Attempt
  * @returns 
  */
-const ContentDrawer = (props: {attempt: Attempt, configData: any}) => {
-    const { attempt, configData } = props;
+const ContentDrawer = (props: {attempt: Attempt}) => {
+    const { attempt } = props;
     const { flowId, runNumber, taskId, tab, stepName } = useParams();
+    const {data: manifest} = useManifest();
+    const {data: configData} = useConfig(manifest);
     const navigate = useNavigate();
     const action : Row = getRow(attempt, stepName || 'err');
     
-    const isActionInConfig = () => {
-        const allActions = Object.keys(configData.actions).sort();
-        const isIn = allActions.includes(action.step_name);
-        console.log(isIn);
-        return isIn;
-    }
+    const isActionInConfig = () => (configData && configData.actions[action.step_name])
 
     const handleClick = () => {
         navigate(`/config/actions/${action.step_name}`);

--- a/src/components/WorkflowsExplorer/Run/Run.tsx
+++ b/src/components/WorkflowsExplorer/Run/Run.tsx
@@ -1,7 +1,7 @@
 import { useFetchRun } from "../../../hooks/useFetchData";
 import Attempt from "../../../util/WorkflowsExplorer/Attempt";
 import TabNav from "./Tabs";
-import { useLocation } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import PageHeader from "../../../layouts/PageHeader";
 import { CircularProgress } from "@mui/joy";
 import { displayProps } from "../../ConfigExplorer/DataDisplayView";
@@ -16,8 +16,8 @@ import NotFound from "../../../layouts/NotFound";
     @returns {JSX.Element} - The Run component UI.
 */
 const Run = (props : {panelOpen?: boolean, configData: displayProps}) => {
-    const links = [...useLocation().pathname.split('/')].splice(1);
-    const { data, isLoading, isFetching } = useFetchRun(links[1], parseInt(links[2]), parseInt(links[3]));
+    const {flowId, runNumber, taskId, tab} = useParams();
+    const { data, isLoading, isFetching } = useFetchRun(flowId!, parseInt(runNumber!), parseInt(taskId!));
 
     if (isLoading || isFetching) return <CircularProgress/>
     

--- a/src/components/WorkflowsExplorer/Run/Run.tsx
+++ b/src/components/WorkflowsExplorer/Run/Run.tsx
@@ -1,11 +1,10 @@
+import { CircularProgress } from "@mui/joy";
+import { useParams } from "react-router-dom";
 import { useFetchRun } from "../../../hooks/useFetchData";
+import NotFound from "../../../layouts/NotFound";
+import PageHeader from "../../../layouts/PageHeader";
 import Attempt from "../../../util/WorkflowsExplorer/Attempt";
 import TabNav from "./Tabs";
-import { useLocation, useParams } from "react-router-dom";
-import PageHeader from "../../../layouts/PageHeader";
-import { CircularProgress } from "@mui/joy";
-import { displayProps } from "../../ConfigExplorer/DataDisplayView";
-import NotFound from "../../../layouts/NotFound";
 
 /**
     The Run component displays information about a specific run of a workflow.
@@ -15,7 +14,7 @@ import NotFound from "../../../layouts/NotFound";
     @param {boolean} props.panelOpen - Indicates whether the details panel is open or not.
     @returns {JSX.Element} - The Run component UI.
 */
-const Run = (props : {panelOpen?: boolean, configData: displayProps}) => {
+const Run = (props : {panelOpen?: boolean}) => {
     const {flowId, runNumber, taskId, tab} = useParams();
     const { data, isLoading, isFetching } = useFetchRun(flowId!, parseInt(runNumber!), parseInt(taskId!));
 
@@ -31,7 +30,7 @@ const Run = (props : {panelOpen?: boolean, configData: displayProps}) => {
                 <>
                     <PageHeader title= {attempt.runInfo.workflowName + ': run ' + attempt.runInfo.runId} />
                     {/* <RunDetails attempt={attempt}/> */}
-                    <TabNav attempt={attempt} panelOpen={props.panelOpen} configData={props.configData}/>
+                    <TabNav attempt={attempt} panelOpen={props.panelOpen}/>
                 </>
                 ):(
                     <>

--- a/src/components/WorkflowsExplorer/Run/Tabs.tsx
+++ b/src/components/WorkflowsExplorer/Run/Tabs.tsx
@@ -1,30 +1,29 @@
-import React, { useState } from "react";
-import Tabs from '@mui/joy/Tabs';
-import TabList from '@mui/joy/TabList';
-import Tab, { tabClasses } from '@mui/joy/Tab';
-import TabPanel from '@mui/joy/TabPanel';
-import { Box, IconButton, Sheet, Typography } from "@mui/joy";
-import Attempt from "../../../util/WorkflowsExplorer/Attempt";
-import TableOfActions from "./ActionsTable";
-import { ThemeProvider } from 'styled-components';
-import ContentDrawer from './ContentDrawer';
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import theme from "../../../theme";
-import GlobalStyle from "../../../GlobalStyle";
-import VirtualizedTimeline from "../Timeline/VirtualizedTimeline";
-import { Row } from "../../../types";
-import ToolBar from "../ToolBar/ToolBar";
 import InboxIcon from '@mui/icons-material/Inbox';
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
 import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
-import { checkFiltersAvailability, defaultFilters } from "../../../util/WorkflowsExplorer/StatusInfo";
-import { displayProps } from "../../ConfigExplorer/DataDisplayView";
-import LineageTab from "../../ConfigExplorer/LineageTab";
+import { Box, IconButton, Sheet, Typography } from "@mui/joy";
+import Tab, { tabClasses } from '@mui/joy/Tab';
+import TabList from '@mui/joy/TabList';
+import TabPanel from '@mui/joy/TabPanel';
+import Tabs from '@mui/joy/Tabs';
+import React, { useState } from "react";
 import { ReactFlowProvider } from "react-flow-renderer";
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import GlobalStyle from "../../../GlobalStyle";
+import theme from "../../../theme";
+import { Row } from "../../../types";
+import Attempt from "../../../util/WorkflowsExplorer/Attempt";
+import { checkFiltersAvailability, defaultFilters } from "../../../util/WorkflowsExplorer/StatusInfo";
+import LineageTab from "../../ConfigExplorer/LineageTab";
+import VirtualizedTimeline from "../Timeline/VirtualizedTimeline";
+import ToolBar from "../ToolBar/ToolBar";
+import TableOfActions from "./ActionsTable";
+import ContentDrawer from './ContentDrawer';
 
-import { Lineage } from "../../../util/WorkflowsExplorer/Lineage";
-import { DAGraph } from "../../../util/ConfigExplorer/Graphs";
 import DraggableDivider from "../../../layouts/DraggableDivider";
+import { DAGraph } from "../../../util/ConfigExplorer/Graphs";
+import { Lineage } from "../../../util/WorkflowsExplorer/Lineage";
 
 /**
  * This is a TypeScript function that returns a set of three React components which are rendered inside a parent component. 
@@ -36,14 +35,14 @@ import DraggableDivider from "../../../layouts/DraggableDivider";
  * @param {boolean} props.open - Determines whether or not the content drawer is open for the timeline and actions table components 
  * @returns A set of three React components (ToolBar, Tabs, TabPanel) rendered inside a parent component.
  */
-const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolean}) => {
-    const { attempt, open, configData } = props;
+const TabsPanels = (props: { attempt: Attempt, open?: boolean }) => {
+    const { attempt, open } = props;
     const defaultRows = attempt.rows;
     const [rows, setRows] = useState<Row[]>(defaultRows);
     const [checked, setChecked] = useState([
-        {name: 'Execution', checked: true}, 
-        {name: 'Initialized', checked: false}, 
-        {name: 'Prepared', checked: false}
+        { name: 'Execution', checked: true },
+        { name: 'Initialized', checked: false },
+        { name: 'Prepared', checked: false }
     ]);
     const navigate = useNavigate();
     const location = useLocation().pathname;
@@ -58,46 +57,26 @@ const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolea
         setRows(rows);
     }
 
-    const updateChecked = (checked: {name: string; checked: boolean; }[]) => {
+    const updateChecked = (checked: { name: string; checked: boolean; }[]) => {
         setChecked(checked);
     }
 
-    return ( 
-        <Sheet
-            sx={{
-                display: 'flex',
-                height: '100%',
-            }}
-        >
-            <Sheet
-                sx={{
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    height: '100%', 
-                }}
-            >
+    return (
+        <Sheet sx={{ display: 'flex', height: '100%' }}>
+            <Sheet sx={{ flex: 1, display: 'flex', flexDirection: 'column', height: '100%' }}>
                 {/* Renders the ToolBar component, which contains a set of buttons that allow the user to filter the rows displayed in the actions table */}
-                <Sheet
-                    sx={{
-                        py: '1rem',
-                        my: '1.2rem',
-                        position: 'sticky',
-                        top: '0',
-                        borderRadius: '0.5rem',
-                    }}
-                >
-                    <ToolBar 
-                        controlledRows={defaultRows} 
-                        updateRows={updateRows} 
+                <Sheet sx={{ py: '1rem', my: '1.2rem', position: 'sticky', top: '0', borderRadius: '0.5rem' }}>
+                    <ToolBar
+                        controlledRows={defaultRows}
+                        updateRows={updateRows}
                         filters={checkFiltersAvailability(defaultRows, defaultFilters())}
                         sortEnabled={true}
                         searchColumn={"step_name"}
                         searchPlaceholder="Search by action name"
                         searchMode="contains"
                         updateChecked={attempt.runInfo.runStateFormatVersion && attempt.runInfo.runStateFormatVersion > 1 ? updateChecked : undefined}
-                        />
-                    
+                    />
+
                 </Sheet>
                 {/* Renders either an icon and message indicating that no actions were found, or the VirtualizedTimeline/Table and ContentDrawer components */}
                 {rows.length === 0 ? (
@@ -128,51 +107,43 @@ const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolea
                 ) : (
                     <Sheet>
                         <TabPanel className='timeline-panel' value={0} sx={{ py: '1rem' }}>
-                            <Sheet 
-                                sx={{
-                                    display: 'flex',
-                                    gap: '0.5rem',
-                                    height: '100%',
-                                    position: 'relative',  
-                                    
-                                }}
-                            >
-                                    <ThemeProvider theme={theme}>
+                            <Sheet sx={{ display: 'flex', gap: '0.5rem', height: '100%', position: 'relative',}} >
+                                <ThemeProvider theme={theme}>
                                     <GlobalStyle />
+                                    <Sheet
+                                        onClick={() => {
+                                            if (open) {
+                                                navigate(`${location.split('timeline')[0]}timeline`);
+                                            }
+                                        }}
+                                        sx={{
+                                            flex: '1',
+                                            width: '99%',
+                                            position: 'absolute',
+                                            top: 0,
+                                            left: 0,
+                                            backgroundColor: open ? 'primary.main' : 'none',
+                                            opacity: open ? [0.4, 0.4, 0.4] : [],
+                                            transition: 'opacity 0.2s ease-in-out',
+                                            cursor: 'context-menu'
+                                        }}
+                                    >
                                         <Sheet
-                                            onClick={() => {
-                                                if (open) {
-                                                    navigate(`${location.split('timeline')[0]}timeline`);
-                                                }
-                                            }}
                                             sx={{
-                                                flex: '1',
-                                                width: '99%',
-                                                position: 'absolute', 
-                                                top: 0,
-                                                left: 0,
-                                                backgroundColor: open ? 'primary.main' : 'none',
-                                                opacity: open ? [0.4, 0.4, 0.4] : [],
-                                                transition: 'opacity 0.2s ease-in-out',
-                                                cursor: 'context-menu'
+                                                gap: '0.5rem',
+                                                height: '69vh',
+                                                display: 'flex',
                                             }}
                                         >
-                                            <Sheet 
-                                sx={{
-                                    gap: '0.5rem',
-                                    height: '69vh',
-                                    display: 'flex',
-                                }}
-                            >
 
-                                            <VirtualizedTimeline run={attempt.run} rows={rows} displayPhases={checked}/>
-                            </Sheet>
+                                            <VirtualizedTimeline run={attempt.run} rows={rows} displayPhases={checked} />
                                         </Sheet>
-                                    </ThemeProvider>
-                            </Sheet> 
+                                    </Sheet>
+                                </ThemeProvider>
+                            </Sheet>
                         </TabPanel>
                         <TabPanel className='actions-table-panel' value={1} sx={{ py: '1rem' }}>
-                            <Sheet 
+                            <Sheet
                                 sx={{
                                     gap: '0.5rem',
                                     height: '69vh',
@@ -197,7 +168,7 @@ const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolea
                                         cursor: 'context-menu'
                                     }}
                                 >
-                                    <TableOfActions rows={rows}/>
+                                    <TableOfActions rows={rows} />
                                 </Sheet>
                             </Sheet>
                         </TabPanel>
@@ -206,12 +177,12 @@ const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolea
                         </TabPanel>
                     </Sheet>
                 )}
-            </Sheet> 
+            </Sheet>
             {open && (
                 <>
                     {/* <Sheet sx={{borderLeft: '1px solid lightgray', ml: '2rem', mr: '1rem'}}/> */}
                     <Sheet
-                        sx={{ 
+                        sx={{
                             position: 'absolute',
                             top: 0,
                             height: '80vh',
@@ -222,11 +193,11 @@ const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolea
                             p: '1rem'
                         }}
                     >
-                        <ContentDrawer attempt={attempt} configData={configData}/>
+                        <ContentDrawer attempt={attempt} />
                     </Sheet>
                 </>
             )}
-        </Sheet> 
+        </Sheet>
     );
 }
 
@@ -235,24 +206,24 @@ const TabsPanels = (props : {attempt: Attempt, configData: object, open?: boolea
  * @param props {attempt: Attempt, panelOpen?: boolean}
  * @returns JSX.Element
  */
-const TabNav = (props : {attempt: Attempt, configData: displayProps, panelOpen?: boolean}) => {
+const TabNav = (props: { attempt: Attempt, panelOpen?: boolean }) => {
     const { stepName, tab } = useParams();
-    const [value, setValue] = React.useState(tab === 'timeline' ? 0: 1);
+    const [value, setValue] = React.useState(tab === 'timeline' ? 0 : 1);
     const [openLineage, setOpenLineage] = useState<boolean>(false);
     const [lineageWidth, setLineageWidth] = React.useState(500);
-    const lineageRef = React.useRef<HTMLDivElement>(null);    
-    const { attempt, panelOpen, configData } = props;
-    const navigate =  useNavigate();
+    const lineageRef = React.useRef<HTMLDivElement>(null);
+    const { attempt, panelOpen } = props;
+    const navigate = useNavigate();
 
-    const handleChange = (_e : any, v: any) => {
+    const handleChange = (_e: any, v: any) => {
         setValue(typeof v === 'number' ? v : 0);
         navigate(`/workflows/${attempt.runInfo.workflowName}/${attempt.runInfo.runId}/${attempt.runInfo.attemptId}/${v === 0 ? 'timeline' : 'table'}`)
         if (stepName) navigate(`/workflows/${attempt.runInfo.workflowName}/${attempt.runInfo.runId}/${attempt.runInfo.attemptId}/${v === 0 ? 'timeline' : 'table'}/${stepName}`)
     }
 
-    
+
     const prepareGraph = (rows: Row[]) => {
-        let data: {action: string, inputIds: {id: string}[], outputIds: {id: string}[]}[] = []; 
+        let data: { action: string, inputIds: { id: string }[], outputIds: { id: string }[] }[] = [];
         rows.forEach((row: Row) => {
             data.push({
                 action: row.step_name,
@@ -266,9 +237,9 @@ const TabNav = (props : {attempt: Attempt, configData: displayProps, panelOpen?:
 
     const graph: DAGraph = new Lineage(prepareGraph(attempt.rows)).graph;
 
-    return ( 
-        <Sheet sx={{display: 'flex', height: '100%', px: '1rem'}}>
-            <Sheet 
+    return (
+        <Sheet sx={{ display: 'flex', height: '100%', px: '1rem' }}>
+            <Sheet
                 sx={{
                     flex: 1,
                     height: '100%',
@@ -282,40 +253,40 @@ const TabNav = (props : {attempt: Attempt, configData: displayProps, panelOpen?:
                             mt: '1rem',
                             justifyContent: 'space-between'
                         }}
-                        >
+                    >
                         <TabList variant="plain" sx={style}>
                             <Tab>Timeline</Tab>
                             <Tab>Actions table</Tab>
                         </TabList>
                         {!openLineage ?
                             (
-                                <IconButton disabled={attempt.rows[0].inputIds ? false : true} color={'primary'} size="md" variant="solid" sx={{ml: '1rem', px: '1rem', scale: '80%'}} onClick={() => setOpenLineage(!openLineage)}>
+                                <IconButton disabled={attempt.rows[0].inputIds ? false : true} color={'primary'} size="md" variant="solid" sx={{ ml: '1rem', px: '1rem', scale: '80%' }} onClick={() => setOpenLineage(!openLineage)}>
                                     Open lineage
-                                    <KeyboardDoubleArrowLeftIcon  sx={{ml: '0.5rem'}}/>
+                                    <KeyboardDoubleArrowLeftIcon sx={{ ml: '0.5rem' }} />
                                 </IconButton>
                             ) : (
-                                <IconButton color={'primary'} size="md" variant="soft" sx={{ml: '0.5rem', px: '0.5rem', scale: '80%'}} onClick={() => setOpenLineage(!openLineage)}>
+                                <IconButton color={'primary'} size="md" variant="soft" sx={{ ml: '0.5rem', px: '0.5rem', scale: '80%' }} onClick={() => setOpenLineage(!openLineage)}>
                                     Close lineage
-                                    <KeyboardDoubleArrowRightIcon  sx={{ml: '0.5rem'}}/>
+                                    <KeyboardDoubleArrowRightIcon sx={{ ml: '0.5rem' }} />
                                 </IconButton>
                             )
                         }
                     </Box>
-                    <TabsPanels attempt={attempt} open = {panelOpen} configData={configData}/>
+                    <TabsPanels attempt={attempt} open={panelOpen} />
                 </Tabs>
             </Sheet>
             {openLineage && (
                 <>
-    				<DraggableDivider setWidth={setLineageWidth} cmpRef={lineageRef} isRightCmp={true} />
-                    <Sheet sx={{width: lineageWidth}} ref={lineageRef}>
+                    <DraggableDivider setWidth={setLineageWidth} cmpRef={lineageRef} isRightCmp={true} />
+                    <Sheet sx={{ width: lineageWidth }} ref={lineageRef}>
                         <ReactFlowProvider>
-                            <LineageTab graph={graph} elementName="" elementType=""/>
+                            <LineageTab graph={graph} elementName="" elementType="" />
                         </ReactFlowProvider>
                     </Sheet>
                 </>
             )}
         </Sheet>
-     );
+    );
 }
 
 const style = {
@@ -336,5 +307,5 @@ const style = {
         },
     },
 }
- 
+
 export default TabNav;

--- a/src/components/WorkflowsExplorer/Run/Tabs.tsx
+++ b/src/components/WorkflowsExplorer/Run/Tabs.tsx
@@ -24,8 +24,7 @@ import { ReactFlowProvider } from "react-flow-renderer";
 
 import { Lineage } from "../../../util/WorkflowsExplorer/Lineage";
 import { DAGraph } from "../../../util/ConfigExplorer/Graphs";
-
-export const defaultDrawerWidth = 600;
+import DraggableDivider from "../../../layouts/DraggableDivider";
 
 /**
  * This is a TypeScript function that returns a set of three React components which are rendered inside a parent component. 
@@ -240,6 +239,8 @@ const TabNav = (props : {attempt: Attempt, configData: displayProps, panelOpen?:
     const { stepName, tab } = useParams();
     const [value, setValue] = React.useState(tab === 'timeline' ? 0: 1);
     const [openLineage, setOpenLineage] = useState<boolean>(false);
+    const [lineageWidth, setLineageWidth] = React.useState(500);
+    const lineageRef = React.useRef<HTMLDivElement>(null);    
     const { attempt, panelOpen, configData } = props;
     const navigate =  useNavigate();
 
@@ -305,8 +306,8 @@ const TabNav = (props : {attempt: Attempt, configData: displayProps, panelOpen?:
             </Sheet>
             {openLineage && (
                 <>
-                    <Sheet sx={{borderLeft: '1px solid lightgray', mx: '1rem'}}/>
-                    <Sheet sx={{width: '40%', flex: 1}}>
+    				<DraggableDivider setWidth={setLineageWidth} cmpRef={lineageRef} isRightCmp={true} />
+                    <Sheet sx={{width: lineageWidth}} ref={lineageRef}>
                         <ReactFlowProvider>
                             <LineageTab graph={graph} elementName="" elementType=""/>
                         </ReactFlowProvider>

--- a/src/components/WorkflowsExplorer/Workflow/WorkflowHistory.tsx
+++ b/src/components/WorkflowsExplorer/Workflow/WorkflowHistory.tsx
@@ -1,18 +1,18 @@
-import { useLocation } from "react-router-dom";
-import PageHeader from "../../../layouts/PageHeader";
-import { CircularProgress, Sheet } from "@mui/joy";
-import ToolBar from "../ToolBar/ToolBar";
-import { useFetchWorkflow } from "../../../hooks/useFetchData";
-import { useEffect, useState } from "react";
-import { TablePagination } from "@mui/material";
-import ChartControl from "../HistoryChart/ChartControl";
-import { durationMicro } from "../../../util/WorkflowsExplorer/date";
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { CircularProgress, Sheet } from "@mui/joy";
 import IconButton from '@mui/joy/IconButton';
-import { checkFiltersAvailability, defaultFilters } from "../../../util/WorkflowsExplorer/StatusInfo";
-import WorkflowHistoryTable from "./WorkflowHistoryTable";
+import { TablePagination } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useFetchWorkflow } from "../../../hooks/useFetchData";
 import NotFound from "../../../layouts/NotFound";
+import PageHeader from "../../../layouts/PageHeader";
+import { checkFiltersAvailability, defaultFilters } from "../../../util/WorkflowsExplorer/StatusInfo";
+import { durationMicro } from "../../../util/WorkflowsExplorer/date";
+import ChartControl from "../HistoryChart/ChartControl";
+import ToolBar from "../ToolBar/ToolBar";
+import WorkflowHistoryTable from "./WorkflowHistoryTable";
 
 
 export type Indices = {
@@ -28,9 +28,8 @@ export type Indices = {
  * @returns JSX.Element
 */
 const WorkflowHistory = () => {
-	const links = [...useLocation().pathname.split('/')].splice(1);
-	const workflowName :  string= links[links.length - 1];
-	const { data, isLoading, isFetching } = useFetchWorkflow(workflowName);
+	const {flowId} = useParams();
+	const { data, isLoading, isFetching } = useFetchWorkflow(flowId!);
 	const [rows, setRows] = useState<any[]>([]);
 	const [toDisplay, setToDisplay] = useState<any[]>(rows);
 	const [page, setPage] = useState(0);
@@ -135,7 +134,7 @@ const WorkflowHistory = () => {
 			{data ? (
 				(!data.detail) ? (
 					<>
-						<PageHeader title={workflowName} />             
+						<PageHeader title={flowId!} />             
 						<Sheet
 							sx={{
 								display: 'flex',

--- a/src/components/WorkflowsExplorer/Workflows/Workflows.tsx
+++ b/src/components/WorkflowsExplorer/Workflows/Workflows.tsx
@@ -44,7 +44,6 @@ const Workflows = () => {
         setRows(rows);
     }
 
-    console.log(isLoading, isFetching)
     if (isLoading || isFetching) return <CircularProgress/>;
     if (process.env.NODE_ENV === 'development' && data.detail) console.log(data.detail);
     

--- a/src/components/WorkflowsExplorer/Workflows/Workflows.tsx
+++ b/src/components/WorkflowsExplorer/Workflows/Workflows.tsx
@@ -48,7 +48,7 @@ const Workflows = () => {
     if (isLoading || isFetching) return <CircularProgress/>;
     if (process.env.NODE_ENV === 'development' && data.detail) console.log(data.detail);
     
-    return (      
+    return (    
         <>
             {data ? (
                 (!data.detail) ? (

--- a/src/hooks/useConfig.tsx
+++ b/src/hooks/useConfig.tsx
@@ -1,8 +1,9 @@
+import { ConfigData } from "../util/ConfigExplorer/ConfigData";
 import { getUrlContent, listConfigFiles, readConfigIndexFile, parseTextStrict } from "../util/ConfigExplorer/HoconParser";
 import { Manifest } from "./useManifest";
 import { useQuery } from "react-query";
 
-function getConfig(manifest:Manifest) {
+function getConfig(manifest:Manifest): () => Promise<ConfigData> {
   return () => {
 
     console.log("getConfig Manifest", manifest);
@@ -48,6 +49,7 @@ function getConfig(manifest:Manifest) {
         return parseTextStrict(includeText);
       })
     })
+    .then(parsedConfig => new ConfigData(parsedConfig))
   }
 }
 

--- a/src/hooks/useMemoWithDefault.tsx
+++ b/src/hooks/useMemoWithDefault.tsx
@@ -1,0 +1,7 @@
+import { DependencyList, useMemo } from "react";
+import { withDefault } from "../util/helpers";
+
+export function useMemoWithDefault<Type>(f: () => Type, deps: DependencyList | undefined, defaultValue: Type): Type {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return withDefault(useMemo(f, deps), defaultValue);
+}

--- a/src/layouts/DraggableDivider.tsx
+++ b/src/layouts/DraggableDivider.tsx
@@ -36,6 +36,7 @@ function DraggableDivider(props: { setWidth: (number) => void, cmpRef: MutableRe
 	}
 
 	function onMouseDown(ev: React.MouseEvent<HTMLElement>) {
+		ev.preventDefault();
 		startDrag(ev.clientX);
 	}
 	

--- a/src/layouts/DraggableDivider.tsx
+++ b/src/layouts/DraggableDivider.tsx
@@ -1,0 +1,75 @@
+import { DragIndicator } from '@mui/icons-material';
+import { Divider } from '@mui/material';
+import { MutableRefObject, useEffect, useRef } from 'react';
+
+// some state to keep left component width accross path changes
+const dividerState = new Map<string,number>();
+
+function DraggableDivider(props: { setWidth: (number) => void, cmpRef: MutableRefObject<HTMLDivElement | null>, isRightCmp: boolean}) {
+
+	const leftWidth = useRef<number>();
+	const dragPos = useRef<[number, number]>();
+	const dividerRef = useRef<HTMLHRElement>(null);
+
+	useEffect(() => {
+		document.addEventListener("mousemove", onMouseMove);
+		document.addEventListener("mouseup", endDrag);
+		return () => {
+			document.removeEventListener("mousemove", onMouseMove);
+			document.removeEventListener("mouseup", endDrag);
+		};
+	});
+
+    useEffect(() => {
+        // initialize left componentent width
+        if (dividerRef.current && dividerState[dividerRef.current.nodeName]) {
+            props.setWidth(dividerState[dividerRef.current.nodeName]);
+        }
+    });
+
+	function startDrag(pos: number) {
+		if (props.cmpRef.current && dividerRef.current) {
+			leftWidth.current = props.cmpRef.current.clientWidth;
+			dragPos.current = [pos, pos];
+			dividerRef.current.style.backgroundColor = '#f0f0f0';
+		}
+	}
+
+	function onMouseDown(ev: React.MouseEvent<HTMLElement>) {
+		startDrag(ev.clientX);
+	}
+	
+	function onMouseMove(ev: MouseEvent) {
+		updateDrag(ev.clientX);
+	}
+
+	function updateDrag(pos: number) {
+		if (dragPos.current && props.cmpRef.current) {
+			dragPos.current = [dragPos.current[0], pos];
+    		props.cmpRef.current.style.width = `${getLeftDraggedWidth()}px`;
+		}
+	}
+
+	function endDrag() {
+		if (dragPos.current) {
+            const width = getLeftDraggedWidth()
+			props.setWidth(width);
+            dividerState[dividerRef.current!.nodeName] = width;
+			dragPos.current = undefined;
+			if (dividerRef.current) dividerRef.current.style.backgroundColor = 'white';
+		}
+	}
+
+	function getLeftDraggedWidth() {
+		const sideMultpl = (props.isRightCmp ? -1 : 1);
+		return leftWidth.current! + (dragPos.current ? (dragPos.current[1] - dragPos.current[0]) : 0) * sideMultpl;
+	}
+
+	return (
+		<Divider orientation='vertical' ref={dividerRef} onMouseDown={onMouseDown} sx={{ width: 10, marginLeft: '5px', marginRight: '5px' }}>
+			<DragIndicator sx={{ fontSize: 15, marginLeft: '-12px' }} />
+		</Divider>
+	)
+}
+
+export default DraggableDivider;

--- a/src/layouts/PageHeader.tsx
+++ b/src/layouts/PageHeader.tsx
@@ -24,32 +24,26 @@ const PageHeader = (props: {title : string, subtitle?: string, description?: str
 
     return ( 
             <Sheet sx={{
-                display: 'flex',
-                justifyContent: 'flex-start',
                 alignItems: 'center',
                 position: 'sticky',
                 top: 0,
                 width: '100%',
                 borderBottom: '1px solid lightgray',
-                px : '1rem',
-                pt : '4rem',
-                pb : '1rem',
-                pl: noBack ? '3.5rem' : '1rem',
-                gap: '0.5rem',
-
+                pl : '1.2rem',
+                pr : '0.2rem',
+                pt : '3.2rem',
+                pb : '0.2rem',
             }}>
-                {!noBack && <IconButton  onClick={handleClick} variant="plain" color="neutral" size="sm">
-                    <ArrowBackIosIcon sx={{scale: '80%', pl: '0.3rem'}}/>
-                </IconButton>}
                 <Box sx={{
                     display: 'flex',
-                    flexDirection: 'column',
                     verticalAlign: 'middle',
                     pb: '0.5rem',
-
                 }}>
-                    <Typography level="h3">{title}</Typography>
-                    {subtitle && <Typography level="h4" sx={{pt: '1rem'}}>{subtitle}</Typography>}
+                    {!noBack && <IconButton  onClick={handleClick} variant="plain" color="neutral" size="sm">
+                        <ArrowBackIosIcon sx={{scale: '80%', pl: '0.3rem'}}/>
+                    </IconButton>}
+                    <Typography level="h4">{title}</Typography>
+                    {subtitle && <Typography level="h5" sx={{pt: '1rem'}}>{subtitle}</Typography>}
                     {description && <Typography level="body2" sx={{py: '1rem'}}>{description}</Typography>}
                 </Box>
             </Sheet>

--- a/src/layouts/SideBar.tsx
+++ b/src/layouts/SideBar.tsx
@@ -3,8 +3,9 @@ import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import SpeedRoundedIcon from '@mui/icons-material/SpeedRounded';
 import TuneRoundedIcon from '@mui/icons-material/TuneRounded';
 import { Box, Divider, List, ListItem /* , ListItemContent */, ListItemButton, Sheet, Tooltip } from '@mui/joy';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useMatch, useNavigate, useResolvedPath } from 'react-router-dom';
 import { useManifest } from '../hooks/useManifest';
+import { ListItemIcon } from '@mui/material';
 
 /**
  * The SideBar is a navigation bar that is fixed on the left side of the screen. It contains buttons that allow the user to navigate to different pages, such as the Home page, Workflows Explorer page, and Config Viewer page.
@@ -13,7 +14,19 @@ import { useManifest } from '../hooks/useManifest';
 const SideBar = () => {
     const manifest = useManifest();
     const navigate = useNavigate();
-    
+    const location = useLocation();
+
+    function getModulePath() {
+        const secondSlashPos = location.pathname.indexOf('/',1);
+        if (secondSlashPos>0) {
+            return location.pathname.substring(0, secondSlashPos);
+        } else {
+            return location.pathname;
+        }
+    }
+
+    console.log(location.pathname, getModulePath());
+
     if (manifest.isLoading) return <></>
     
     const buttons = [
@@ -37,7 +50,6 @@ const SideBar = () => {
             description: 'Config Viewer'
         }
     ]
-
 
     return ( 
         <Sheet
@@ -68,15 +80,10 @@ const SideBar = () => {
                                 <Tooltip title={component.disabled ? `No data was found for the menu "${component.description.toLowerCase()}". Please check that the ${component.filetype} files are at the expected location according to the manifest.` : component.description} placement='right'>
                                     <div>
                                     <ListItemButton 
-                                        sx={{
-                                            borderRadius: 4, 
-                                            scale: '90%',
-                                            justifyContent: 'center',
-                                        }}
+                                        sx={{ scale: '90%', justifyContent: 'center' }}
                                         onClick={() => navigate(component.link)}
-                                        disabled={component.disabled}
-                                        >   
-                                        {component.icon}
+                                        disabled={component.disabled}>
+                                        <ListItemIcon sx={{minWidth: '25px', color: (getModulePath()===component.link ? 'primary.main' : '')}}>{component.icon}</ListItemIcon>                                        
                                     </ListItemButton>
                                     </div>
                                 </Tooltip>

--- a/src/util/ConfigExplorer/ConfigData.ts
+++ b/src/util/ConfigExplorer/ConfigData.ts
@@ -1,0 +1,90 @@
+
+export class ConfigData {
+    public dataObjects = {};
+    public actions = {};
+    public connections = {};
+    public global = {};
+
+    constructor(data: any) {
+        if (data.dataObjects && typeof data.dataObjects === 'object') {
+            this.dataObjects = data.dataObjects;
+        }
+        if (data.actions && typeof data.actions === 'object') {
+            this.actions = data.actions;
+        }
+        if (data.connections && typeof data.connections === 'object') {
+            this.connections = data.connections;
+        }  
+        if (data.global && typeof data.global === 'object') {
+            this.global = data.global;
+        }             
+    }    
+}
+
+/**
+ * ConfigDataLists hold sorted lists of all DataObjects, Actions and Connections. Then it allows to apply filters
+ * and keep the selected lists for the UI.
+ */
+export class InitialConfigDataLists implements ConfigDataLists {
+    public dataObjects: any[] = [];
+    public actions: any[] = [];
+    public connections: any[] = [];    
+
+    constructor(data?: ConfigData) {
+        if (data) {
+            this.dataObjects = this.getSortedEntries(data.dataObjects);
+            this.actions = this.getSortedEntries(data.actions);
+            this.connections = this.getSortedEntries(data.connections);
+        }
+    }
+
+    private getSortedEntries(obj: object): any[] {
+        return Object.entries(obj)
+        .map(([k,v]) => {v.id = k; return v}) // add key as id
+        .sort((a,b) => this.sortString(a.id, b.id)); // sort by id
+    }
+    private sortString(a: string, b: string) {
+        if (a === b) return 0;
+        if (a < b) return -1;
+        else return 1;
+    }
+
+    public applySimpleFilter(str: string) {
+        const filterDef = (obj:any) => obj.id.toLowerCase().includes(str.toLowerCase());
+        return this.applyFilterFunc(filterDef);
+    }
+
+    public applyRegexFilter(regex: string) {
+        const regexObj = new RegExp(regex);
+        const filterDef = (obj:any) => obj.id.match(regexObj);
+        return this.applyFilterFunc(filterDef);
+    }
+
+    public applyTagFilter(tag: string) {
+        const filterDef = (obj:any) => obj.metadata?.tags?.includes(tag);
+        return this.applyFilterFunc(filterDef);
+    }
+
+    public applyTypeFilter(type: string) {
+        const filterDef = (obj:any) => obj.type === type;
+        return this.applyFilterFunc(filterDef);
+    }   
+    
+    private applyFilterFunc(filterFunc: (any) => boolean): ConfigDataLists {
+        return {
+            dataObjects:this.dataObjects.filter(filterFunc),
+            actions: this.actions.filter(filterFunc),
+            connections: this.connections.filter(filterFunc)
+        }
+    }
+
+    public isEmpty() {
+        return (this.dataObjects.length === 0 && this.actions.length === 0 && this.connections.length === 0);
+    }
+}
+
+export interface ConfigDataLists {
+    dataObjects: any[];
+    actions: any[];
+    connections: any[];
+}

--- a/src/util/WorkflowsExplorer/routing.ts
+++ b/src/util/WorkflowsExplorer/routing.ts
@@ -1,8 +1,3 @@
-import { createHashRouter, createRoutesFromElements, Route } from 'react-router-dom';
-import WorkflowHistory from '../../components/WorkflowsExplorer/Workflow/WorkflowHistory';
-import Workflows from '../../components/WorkflowsExplorer/Workflows/Workflows';
-import NotFound from '../../layouts/NotFound';
-import RootLayout from '../../layouts/RootLayout';
 import { Row } from '../../types';
 
 type PathValue = string | number;
@@ -28,16 +23,3 @@ export const getPathFor = {
   attempt: (item: Row): string =>
   `/workflows/${item.flow_id}/${item.run_number}/${item.task_id}/timeline/${item.step_name}`,
 };
-
-export const router = createHashRouter(
-    createRoutesFromElements(
-      <Route path='/' element={<RootLayout isLoading={false}/>}>{/* 
-        <Route path='/configviewer' element={<ConfigViewer/>}/> */}
-        <Route path='/workflows/' element={<Workflows/>}/>
-        <Route path='/workflows/:workflow' element={<WorkflowHistory/>}/>
-        {/* <Route path='/workflows/:flowId/:runNumber/:taskId/:tab' element={<Run/>}/>
-        <Route path='/workflows/:flowId/:runNumber/:taskId/:tab/:stepName' element={<Run panelOpen={true} lineageData={[]}/>}/> */}
-        <Route path='*' element={<NotFound/>}/>
-      </Route>
-    )
-)

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,0 +1,11 @@
+
+/**
+ * Function to transform a value by a function if it is defined, and otherwise returns a default value.
+ */
+export function transformOrDefault<In,Out>(input: In, f: (In) => Out, defaultVal: Out) {
+    return (input ? f(input) : defaultVal);
+}
+
+export function withDefault<Type>(input: Type, defaultVal: Type) {
+    return (input ? input : defaultVal);
+}


### PR DESCRIPTION
- simplify routing, fix loading config element (sometimes crashed because not yet loaded)
- add dragable divider for element list and lineage tab
- add table view of elements on routes /config/(dataObjects|actions|connections)
- highlight current selected module & element in primary color