### PR TITLE
Keep the run and workflow filters applied when data is refreshed (#115)

### DIFF
--- a/src/components/WorkflowsExplorer/Run/Tabs.tsx
+++ b/src/components/WorkflowsExplorer/Run/Tabs.tsx
@@ -63,8 +63,10 @@ const TabsPanels = (props: { attempt: Attempt, tab: string }) => {
         return timelineRun;
     }, [data, filterParams]);
 
+	// merge into the previous value: the filter menus report their initial selection on mount, so two
+	// of them updating in the same render must not overwrite each other
 	function updateFilterParams(partialFilter: Partial<FilterParams>) {
-		setFilterParams({...filterParams, ...partialFilter})
+		setFilterParams(prev => ({...prev, ...partialFilter}))
 	}
 
     const graph: PartialDataObjectsAndActions = useMemo(() => {
@@ -83,7 +85,7 @@ const TabsPanels = (props: { attempt: Attempt, tab: string }) => {
         <Sheet sx={{ flex: 1, display: 'flex', flexDirection: 'column', mt: '1rem', mb: '1rem', width: '100%', height: '100%', overflow: 'hidden' }}>
             {tab !== "graph" && 
                 <ToolBar data={data} filterParams={filterParams} updateFilterParams={updateFilterParams} searchPlaceholder="Search by action name"
-                    stateFilters={checkFiltersAvailability(data, stateFilters('status'))} attemptFilters={attemptFilterDefs}                
+                    stateFilters={checkFiltersAvailability(data, stateFilters('status'))} attemptFilters={attemptFilterDefs} storageKeyPrefix="run"
                     leftElements={additionalLeftToolbarElements} rightElements={additionalRightToolbarElements}
                 />
             }

--- a/src/components/WorkflowsExplorer/ToolBar/ToolBar.tsx
+++ b/src/components/WorkflowsExplorer/ToolBar/ToolBar.tsx
@@ -4,6 +4,7 @@ import DatetimePicker from "../DatetimePicker/DatetimePicker";
 import { NEUTRAL_COLOR, getStatusColor } from "../../../util/WorkflowsExplorer/statusColors";
 import { FilterParams } from "../WorkflowHistory";
 import FilterMenu from "./FilterMenu";
+import useLocalStorageState from "../../../hooks/useLocalStorageState";
 
 
 /**
@@ -16,17 +17,30 @@ import FilterMenu from "./FilterMenu";
  */
 const ToolBar = (
     props: {
-        data: any[], 
-        filterParams: FilterParams,        
+        data: any[],
+        filterParams: FilterParams,
         updateFilterParams: (params: Partial<FilterParams>) => void,
         stateFilters: Filter[],
         attemptFilters?: Filter[],
         datetimePicker?: boolean,
         searchPlaceholder?: string,
+        storageKeyPrefix: string,
         leftElements?: JSX.Element,
         rightElements?: JSX.Element,
     }) => {
-    const { data, filterParams, updateFilterParams, stateFilters, attemptFilters, datetimePicker, searchPlaceholder, leftElements, rightElements } = props;
+    const { data, filterParams, updateFilterParams, stateFilters, attemptFilters, datetimePicker, searchPlaceholder, storageKeyPrefix, leftElements, rightElements } = props;
+
+    /*
+      The selected filters are remembered per page, because the pages remount when their data is
+      refreshed (see Run) and the selection would otherwise fall back to its default while the menus
+      still showed it as set - issue #115.
+
+      Only the *names* are stored: a Filter carries a predicate, which does not survive
+      JSON.stringify, so the Filter objects are rebuilt from the definitions the page passes in.
+      A name that the refreshed data has no filter for anymore is simply not found again.
+    */
+    const [selectedStates, setSelectedStates] = useLocalStorageState<string[] | undefined>(`${storageKeyPrefix}.filter.state`, undefined);
+    const [selectedAttempts, setSelectedAttempts] = useLocalStorageState<string[] | undefined>(`${storageKeyPrefix}.filter.attempt`, undefined);
 
     function setSearchText(text: string) {
         const searchText = (text.trim().length > 0 ? text.trim() : undefined);    
@@ -36,22 +50,33 @@ const ToolBar = (
     function setStateFilters(filters: Filter[]) {
         const otherFilters = filterParams.additionalFilters.filter(f => f.group != 'state');
         const newAdditionalFilters = otherFilters.concat(filters);
-        updateFilterParams({additionalFilters: newAdditionalFilters})    
+        setSelectedStates(filters.map(f => f.name));
+        updateFilterParams({additionalFilters: newAdditionalFilters})
     }
 
     function setAttemptsFilters(filters: Filter[]) {
         const otherFilters = filterParams.additionalFilters.filter(f => f.group != 'attempt');
         const newAdditionalFilters = otherFilters.concat(filters);
-        updateFilterParams({additionalFilters: newAdditionalFilters})    
+        setSelectedAttempts(filters.map(f => f.name));
+        updateFilterParams({additionalFilters: newAdditionalFilters})
     }
 
     function setDateRange(range?: [Date,Date]) {
         updateFilterParams({dateRange: range})    
     }    
     
-    // enable only the last attempt by default
+    // restore the remembered selection, or enable only the last attempt by default
     const attemptFilterInit = (attemptFilters ? attemptFilters.map(_ => false) : []);
-    if (attemptFilters) attemptFilterInit[attemptFilterInit.length -1] = true;
+    if (attemptFilters) {
+        if (selectedAttempts) {
+            attemptFilters.forEach((f, idx) => attemptFilterInit[idx] = selectedAttempts.includes(f.name));
+        } else {
+            attemptFilterInit[attemptFilterInit.length -1] = true;
+        }
+    }
+
+    // restore the remembered selection, or enable all states by default
+    const stateFilterInit = stateFilters?.map(f => selectedStates ? selectedStates.includes(f.name) : true);
 
     return (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
@@ -62,7 +87,7 @@ const ToolBar = (
                 onChange={(event) => setSearchText(event.target.value)}
             />
             {attemptFilters && attemptFilters.length>1 && <FilterMenu title='Select Attempts' filters={attemptFilters} setFilters={setAttemptsFilters} filterInit={attemptFilterInit} colorMap={() => NEUTRAL_COLOR}/>}
-            {stateFilters && <FilterMenu title='Filter Status' filters={stateFilters} setFilters={setStateFilters} colorMap={getStatusColor} withIcon={true}/>}
+            {stateFilters && <FilterMenu title='Filter Status' filters={stateFilters} setFilters={setStateFilters} filterInit={stateFilterInit} colorMap={getStatusColor} withIcon={true}/>}
             {datetimePicker && <DatetimePicker range={filterParams.dateRange} setRange={setDateRange}/>}
             {leftElements && leftElements}
             <Box sx={{flex: 1}}/>

--- a/src/components/WorkflowsExplorer/WorkflowHistory.tsx
+++ b/src/components/WorkflowsExplorer/WorkflowHistory.tsx
@@ -141,8 +141,10 @@ export default function WorkflowHistory() {
 		}
     }, [data, filterParams])
 
+	// merge into the previous value: the filter menus report their initial selection on mount, so two
+	// of them updating in the same render must not overwrite each other
 	function updateFilterParams(partialFilter: Partial<FilterParams>) {
-		setFilterParams({...filterParams, ...partialFilter})
+		setFilterParams(prev => ({...prev, ...partialFilter}))
 	}
 
 	function refreshData() {
@@ -182,6 +184,7 @@ export default function WorkflowHistory() {
 					searchPlaceholder={'Search by Run ID'}
 					stateFilters={checkFiltersAvailability(data, stateFilters('status'))}
 					filterParams={filterParams}
+					storageKeyPrefix="workflowHistory"
 					datetimePicker={true}
                     leftElements={additionalLeftToolbarElements}
                     rightElements={additionalRightToolbarElements}/>

--- a/src/components/WorkflowsExplorer/Workflows.tsx
+++ b/src/components/WorkflowsExplorer/Workflows.tsx
@@ -71,8 +71,10 @@ export default function Workflows() {
 
     if (isLoading || isFetching) return <CenteredCircularProgress/>;
     
+	// merge into the previous value: the filter menus report their initial selection on mount, so two
+	// of them updating in the same render must not overwrite each other
 	function updateFilterParams(partialFilter: Partial<FilterParams>) {
-		setFilterParams({...filterParams, ...partialFilter})
+		setFilterParams(prev => ({...prev, ...partialFilter}))
 	}
 
 	function refreshData() {
@@ -91,6 +93,7 @@ export default function Workflows() {
                         updateFilterParams={updateFilterParams}
                         stateFilters={checkFiltersAvailability(data, stateFilters('lastStatus'))}
                         searchPlaceholder="Search by name"
+                        storageKeyPrefix="workflows"
                         leftElements={additionalLeftToolbarElements}
                         rightElements={additionalRightToolbarElements}    
                     />

--- a/tests/e2e/workflows.spec.ts
+++ b/tests/e2e/workflows.spec.ts
@@ -73,4 +73,27 @@ test.describe('workflows explorer', () => {
     await expect(page.getByRole('row', { name: /^compute-distances / })).toBeVisible();
     await expect(page.getByRole('row', { name: /^download-airports / })).toBeHidden();
   });
+
+  // issue #115: refreshing remounts the page, which used to reset the filters to their default
+  // while the menus still showed the selection
+  test('the status filter stays applied when the data is refreshed', async ({ page }) => {
+    await page.goto(`/#/workflows/${WORKFLOW}/24.1/table`);
+    await expect(page.getByRole('row', { name: /^compute-distances / })).toBeVisible();
+
+    // compute-distances and join-departures-airports were cancelled in attempt 24.1
+    await page.getByRole('button', { name: 'Filter Status' }).click();
+    await page.getByRole('menuitem').filter({ hasText: 'Cancelled' }).getByRole('checkbox').click();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('row', { name: /^compute-distances / })).toBeHidden();
+
+    await page.getByTestId('RefreshOutlinedIcon').click();
+
+    await expect(page.getByRole('row', { name: /^download-airports / })).toBeVisible();
+    await expect(page.getByRole('row', { name: /^compute-distances / })).toBeHidden();
+    await expect(page.getByRole('row', { name: /^join-departures-airports / })).toBeHidden();
+    // and the menu still shows what is applied
+    await page.getByRole('button', { name: 'Filter Status' }).click();
+    await expect(page.getByRole('menuitem').filter({ hasText: 'Cancelled' }).getByRole('checkbox')).not.toBeChecked();
+    await expect(page.getByRole('menuitem').filter({ hasText: 'Succeeded' }).getByRole('checkbox')).toBeChecked();
+  });
 });


### PR DESCRIPTION
see #115 